### PR TITLE
Make timeout arg working

### DIFF
--- a/riak/mapreduce.py
+++ b/riak/mapreduce.py
@@ -155,7 +155,7 @@ class RiakMapReduce(object):
         """
         Run the map/reduce operation. Returns an array of results, or an
         array of RiakLink objects if the last phase is a link phase.
-        @param integer timeout - Timeout in seconds.
+        @param integer timeout - Timeout in milliseconds.
         @return array()
         """
         num_phases = len(self._phases)


### PR DESCRIPTION
`timeout` arg wasn't passed to transport, and so was not passed to riak
Also timeout has to be expressed in milliseconds and not in seconds as the riak docs says.
