### PR TITLE
Patch recv_pkt to fix short read error from bug #695

### DIFF
--- a/riak/transports/pbc.py
+++ b/riak/transports/pbc.py
@@ -394,9 +394,6 @@ class RiakPbcTransport(RiakTransport):
         while len(self._inbuf) < msglen:
             want_len = min(8192, msglen - len(self._inbuf))
             recv_buf = self._sock.recv(want_len)
-            if len(recv_buf) != want_len:
-                raise RiakError("Socket returned short read {0} - expected {1}".
-                                format(len(recv_buf), want_len))
             self._inbuf += recv_buf
 
 


### PR DESCRIPTION
Removed the following three lines from pbc.py under the length check for recv_pkt to resolve bug #695:

if len(recv_buf) != want_len: 
                raise RiakError("Socket returned short read {0} - expected {1}". 
                                format(len(recv_buf), want_len)) 
