### PR TITLE
bz://695 fix - check packet length not individual reads

### DIFF
--- a/riak/transports/pbc.py
+++ b/riak/transports/pbc.py
@@ -394,11 +394,11 @@ class RiakPbcTransport(RiakTransport):
         while len(self._inbuf) < msglen:
             want_len = min(8192, msglen - len(self._inbuf))
             recv_buf = self._sock.recv(want_len)
-            if len(recv_buf) != want_len:
-                raise RiakError("Socket returned short read {0} - expected {1}".
-                                format(len(recv_buf), want_len))
+            if not recv_buf: break
             self._inbuf += recv_buf
-
+        if len(self._inbuf) != self._inbuf_len:
+            raise RiakError("Socket returned short packet {0} - expected {1}".
+                            format(len(self._inbuf), self._inbuf_len))
 
     def decode_contents(self, rpb_contents):
         contents = []


### PR DESCRIPTION
This is an alternative fix than https://github.com/basho/riak-python-client/pull/8 for bz://695.

Instead of removing the per-recv check it moves it to check the packet length is correct.
