### PR TITLE
honor return_body in riak_object.py and transport/http.py

### DIFF
--- a/riak/riak_object.py
+++ b/riak/riak_object.py
@@ -267,7 +267,7 @@ class RiakObject(object):
         # Issue the get over our transport
         t = self._client.get_transport()
         Result = t.put(self, w, dw, return_body)
-        if Result is not None:
+        if return_body and Result is not None:
             self.populate(Result)
 
         return self

--- a/riak/transports/http.py
+++ b/riak/transports/http.py
@@ -91,7 +91,7 @@ class RiakHttpTransport(RiakTransport) :
         Serialize put request and deserialize response
         """
        # Construct the URL...
-        params = {'returnbody' : 'true', 'w' : w, 'dw' : dw}
+        params = {'returnbody' : ['false', 'true'][return_body], 'w' : w, 'dw' : dw}
         host, port, url = self.build_rest_path(robj.get_bucket(), robj.get_key(),
                                                None, params)
 
@@ -116,7 +116,7 @@ class RiakHttpTransport(RiakTransport) :
 
         # Run the operation.
         response = self.http_request('PUT', host, port, url, headers, content)
-        return self.parse_body(response, [200, 300])
+        return self.parse_body(response, [200, 204, 300])
 
     def delete(self, robj, rw):
         # Construct the URL...


### PR DESCRIPTION
in short:
- include the value passed by client code in the request (with ['false', 'true'][return_body])
- accept 204 as a return code
- don't try to populate an object is return_body=False was passed

NB - I just noticed there was another pull request for this ! Choice !
