### PR TITLE
Add proper user metadata support

### DIFF
--- a/riak/riak_object.py
+++ b/riak/riak_object.py
@@ -47,7 +47,7 @@ class RiakObject(object):
         self._encode_data = True
         self._vclock = None
         self._data = None
-        self._metadata = {}
+        self._metadata = {MD_USERMETA: {}}
         self._links = []
         self._siblings = []
         self._exists = False
@@ -156,6 +156,25 @@ class RiakObject(object):
         :rtype: data
         """
         self._metadata = metadata
+        return self
+
+    def get_usermeta(self):
+        if MD_USERMETA in self._metadata:
+          return self._metadata[MD_USERMETA]
+        else:
+          return {}
+
+    def set_usermeta(self, usermeta):
+        """
+        Sets the custom user metadata on this object. This doesn't include things
+        like content type and links, but only user-defined meta attributes stored
+        with the Riak object.
+
+        :param userdata: The user metadata to store.
+        :type userdata: dict
+        :rtype: data
+        """
+        self._metadata[MD_USERMETA] = usermeta
         return self
 
     def exists(self):

--- a/riak/tests/test_all.py
+++ b/riak/tests/test_all.py
@@ -419,6 +419,16 @@ class BaseTestCase(object):
         obj = bucket.get_binary('foo_from_file')
         self.assertEqual(obj.get_content_type(), 'application/octet-stream')
 
+    def test_store_metadata(self):
+        bucket = self.client.bucket('bucket')
+        rand = self.randint()
+        obj = bucket.new('fooster', rand)
+        obj.set_usermeta({'custom': 'some metadata'})
+        obj.store()
+        obj = bucket.get('fooster')
+        print(obj.get_usermeta())
+        self.assertEqual('some metadata', obj.get_usermeta()['custom'])
+
     def test_store_binary_object_from_file_should_fail_if_file_not_found(self):
         bucket = self.client.bucket('bucket')
         rand = str(self.randint())

--- a/riak/transports/http.py
+++ b/riak/transports/http.py
@@ -112,6 +112,9 @@ class RiakHttpTransport(RiakTransport) :
                 if headers['Link'] != '': headers['Link'] += ', '
                 headers['Link'] += self.to_link_header(link)
 
+        for key, value in robj.get_usermeta().iteritems():
+            headers['X-Riak-Meta-%s' % key] = value
+
         content = robj.get_encoded_data()
 
         # Run the operation.
@@ -247,7 +250,7 @@ class RiakHttpTransport(RiakTransport) :
 
         # Parse the headers...
         vclock = None
-        metadata = {}
+        metadata = {MD_USERMETA: {}}
         links = []
         for header, value in headers.iteritems():
             if header == 'content-type':
@@ -263,7 +266,7 @@ class RiakHttpTransport(RiakTransport) :
             elif header == 'last-modified':
                 metadata[MD_LASTMOD] = value
             elif header.startswith('x-riak-meta-'):
-                metadata[MD_USERMETA][header] = value
+                metadata[MD_USERMETA][header.replace('x-riak-meta-', '')] = value
             elif header == 'x-riak-vclock':
                 vclock = value
         if links != []:

--- a/riak/transports/pbc.py
+++ b/riak/transports/pbc.py
@@ -456,7 +456,7 @@ class RiakPbcTransport(RiakTransport):
             elif k == MD_ENCODING:
                 rpb_content.charset = v
             elif k == MD_USERMETA:
-                for uk, uv in v:
+                for uk, uv in v.iteritems():
                     pair = rpb_content.usermeta.add()
                     pair.key = uk
                     pair.value = uv


### PR DESCRIPTION
This patch is supposed to be a basis for discussion, as I've mixed feelings whether this is the right way to do it. The improvements are around both transports and the RiakObject class, adding new usermeta setter and getter to the latter, which both access the usermeta key in the metadata dict.

For the future, metadata should maybe just be extracted into a new class, to have one place where stuff like content-type, links and user metadata should go.
