### PR TITLE
Let Riak assign a random key

### DIFF
--- a/riak/tests/test_all.py
+++ b/riak/tests/test_all.py
@@ -458,6 +458,15 @@ class RiakHttpTransportTestCase(BaseTestCase, unittest.TestCase):
         o = bucket.new("foo", "bar").store(return_body=False)
         self.assertEqual(o.vclock(), None)
 
+    def test_generate_key(self):
+        # Ensure that Riak generates a random key when
+        # the key passed to bucket.new() is None.
+        bucket = self.client.bucket('random_key_bucket')
+        for key in bucket.get_keys():
+            bucket.get(str(key)).delete()
+        bucket.new(None, data={}).store()
+        self.assertEqual(len(bucket.get_keys()), 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/riak/transports/http.py
+++ b/riak/transports/http.py
@@ -115,9 +115,9 @@ class RiakHttpTransport(RiakTransport) :
         content = robj.get_encoded_data()
 
         # Run the operation.
-        response = self.http_request('PUT', host, port, url, headers, content)
+        response = self.http_request('POST', host, port, url, headers, content)
         if return_body:
-          return self.parse_body(response, [200, 300])
+          return self.parse_body(response, [200, 201, 300])
         else:
           self.check_http_code(response, [204])
           return None


### PR DESCRIPTION
This change makes it possible to pass None as the key argument
to bucket.new(). I'm not sure if you'll want to change the
request method to POST, but it seemed like the simplest way
to make this work. An alternative would be to only change the request
method to POST whenever the key is None, or to refactor the HTTP
transport so that a post() method is called instead of put().
