### PR TITLE
Don't return the empty object (self) with siblings.

### DIFF
--- a/riak/riak_object.py
+++ b/riak/riak_object.py
@@ -461,7 +461,7 @@ class RiakObject(object):
         :type r: integer
         :rtype: array of RiakObject
         """
-        a = [self]
+        a = []
         for i in range(self.get_sibling_count()):
             a.append(self.get_sibling(i, r))
         return a


### PR DESCRIPTION
Very simple change I briefly discussed with @mattmatt last week.

I looked into the Ruby client, and they don't return "self" with their version of get_siblings(). I don't see the purpose of this and the tests still pass.

So now,

```
# assuming 2 conflicting siblings
obj = bucket.get("conflicted-object")
assert(obj.get_data(), None)
assert(obj.get_sibling_count(), 2)
assert(len(obj.get_siblings()), 2)
```

Currently, len(obj.get_siblings() would be 3, as it returns itself ... which has no data.
