### PR TITLE
Fix the test suite when 'test_all.py' is invoked without a path prefix

### DIFF
--- a/riak/tests/test_all.py
+++ b/riak/tests/test_all.py
@@ -478,7 +478,8 @@ class BaseTestCase(object):
     def test_store_binary_object_from_file(self):
         bucket = self.client.bucket('bucket')
         rand = str(self.randint())
-        obj = bucket.new_binary_from_file('foo_from_file', os.path.dirname(__file__) + "/test_all.py")
+        filepath = os.path.join(os.path.dirname(__file__), 'test_all.py')
+        obj = bucket.new_binary_from_file('foo_from_file', filepath)
         obj.store()
         obj = bucket.get_binary('foo_from_file')
         self.assertNotEqual(obj.get_data(), None)
@@ -487,7 +488,9 @@ class BaseTestCase(object):
     def test_store_binary_object_from_file_should_use_default_mimetype(self):
         bucket = self.client.bucket('bucket')
         rand = str(self.randint())
-        obj = bucket.new_binary_from_file('foo_from_file', os.path.dirname(__file__) + '/../../THANKS')
+        filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                os.pardir, os.pardir, 'THANKS')
+        obj = bucket.new_binary_from_file('foo_from_file', filepath)
         obj.store()
         obj = bucket.get_binary('foo_from_file')
         self.assertEqual(obj.get_content_type(), 'application/octet-stream')
@@ -796,7 +799,7 @@ class RiakHttpTransportTestCase(BaseTestCase, MapReduceAliasTestMixIn, unittest.
 
     @unittest.skipIf(SKIP_LUWAK, 'SKIP_LUWAK is defined')
     def test_store_file_with_luwak(self):
-        file = os.path.dirname(__file__) + "/test_all.py"
+        file = os.path.join(os.path.dirname(__file__), "test_all.py")
         with open(file, "r") as input_file:
             data = input_file.read()
 
@@ -805,7 +808,7 @@ class RiakHttpTransportTestCase(BaseTestCase, MapReduceAliasTestMixIn, unittest.
 
     @unittest.skipIf(SKIP_LUWAK, 'SKIP_LUWAK is defined')
     def test_store_get_file_with_luwak(self):
-        file = os.path.dirname(__file__) + "/test_all.py"
+        file = os.path.join(os.path.dirname(__file__), "test_all.py")
         with open(file, "r") as input_file:
             data = input_file.read()
 
@@ -817,7 +820,7 @@ class RiakHttpTransportTestCase(BaseTestCase, MapReduceAliasTestMixIn, unittest.
 
     @unittest.skipIf(SKIP_LUWAK, 'SKIP_LUWAK is defined')
     def test_delete_file_with_luwak(self):
-        file = os.path.dirname(__file__) + "/test_all.py"
+        file = os.path.join(os.path.dirname(__file__), "test_all.py")
         with open(file, "r") as input_file:
             data = input_file.read()
 


### PR DESCRIPTION
The test suite incorrectly uses **file**, assuming that it contains a directory component. More specifically it appends strings rather than using os.path.join(), which can properly detect these situations.
