### PR TITLE
Remove protobuf as a hard requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ if __name__ == "__main__":
         name='riak',
         version='1.3.0',
         packages = find_packages(),
-        install_requires = ['protobuf>=2.3.0', 'urllib3>=0.4.0'],
+        install_requires = ['urllib3>=0.4.0'],
+        tests_require = ['protobuf>=2.3.0'],
         dependency_links = ["http://downloads.basho.com/support"],
         package_data = {
             '' : ['*.proto']


### PR DESCRIPTION
Protobuf currently does not install through any standard python distribution tool, and is also not a requirement to use the Riak Python client and thus should be removed from the list of hard requirements.

This allows anyone to easily pip install riak-python-client without worrying about protobuf unelss they **actually** want to use that transport client.
