### PR TITLE
Remove any leftover objects from a failed test_store_of_missing_object.

### DIFF
--- a/riak/tests/test_all.py
+++ b/riak/tests/test_all.py
@@ -92,6 +92,13 @@ class BaseTestCase(object):
     def setUp(self):
         self.client = self.create_client()
 
+        # make sure these are not left over from a previous, failed run
+        bucket = self.client.bucket('bucket')
+        o = bucket.get('nonexistent_key_json')
+        o.delete()
+        o = bucket.get('nonexistent_key_binary')
+        o.delete()
+
     def test_is_alive(self):
         self.assertTrue(self.client.is_alive())
 


### PR DESCRIPTION
If a test run fails in test_store_of_missing_object, then it may leave the objects around. In the test setup, this will ensure they are missing.
