### PR TITLE
Use simplejson as first choice, json as second choice.

### DIFF
--- a/riak/client.py
+++ b/riak/client.py
@@ -17,11 +17,11 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 """
-# Use json as first choice, simplejson as second choice.
+# Use simplejson as first choice, json as second choice.
 try:
-    import json
-except ImportError:
     import simplejson as json
+except ImportError:
+    import json
 
 from riak.transports import RiakHttpTransport
 from riak.bucket import RiakBucket

--- a/riak/tests/test_all.py
+++ b/riak/tests/test_all.py
@@ -4,9 +4,9 @@ from __future__ import with_statement
 import copy
 import cPickle
 try:
-    import json
-except ImportError:
     import simplejson as json
+except ImportError:
+    import json
 import os
 import random
 import platform

--- a/riak/transports/http.py
+++ b/riak/transports/http.py
@@ -21,9 +21,9 @@ import urllib, re
 from cStringIO import StringIO
 import httplib
 try:
-    import json
-except ImportError:
     import simplejson as json
+except ImportError:
+    import json
 
 from transport import RiakTransport
 from riak.metadata import *

--- a/riak/transports/pbc.py
+++ b/riak/transports/pbc.py
@@ -22,9 +22,9 @@ from __future__ import with_statement
 import socket, struct
 
 try:
-    import json
-except ImportError:
     import simplejson as json
+except ImportError:
+    import json
 
 from transport import RiakTransport
 from riak.metadata import *


### PR DESCRIPTION
Python 2.6, 2.7 json.loads function return unicode.

RiakLink get_bucket method return unicode bucket name but RiakBucket '**init**' method is not support unicode.

Fixed use simplejson as first choice.

'''
Python 2.6.6 (r266:84292, Jun 16 2011, 16:59:16) 
[GCC 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2335.15.00)] on darwin
Type "help", "copyright", "credits" or "license" for more information.

> > > import json
> > > json.**version**
> > > '1.9'
> > > json.loads('[["spam","eggs"]]')
> > > [[u'spam', u'eggs']]

Python 2.7.1 (r271:86832, Dec 11 2010, 20:55:42) 
[GCC 4.2.1 (Apple Inc. build 5664)] on darwin
Type "help", "copyright", "credits" or "license" for more information.

> > > import json
> > > json.**version**
> > > '2.0.9'
> > > json.loads('[["spam","eggs"]]')
> > > [[u'spam', u'eggs']]
> > > import simplejson
> > > simplejson.**version**
> > > '2.1.6'
> > > simplejson.loads('[["spam","eggs"]]')
> > > [['spam', 'eggs']]
> > > '''
