### PR TITLE
Unquote items stored in the link header.

### DIFF
--- a/riak/tests/test_all.py
+++ b/riak/tests/test_all.py
@@ -432,25 +432,23 @@ class BaseTestCase(object):
     def test_store_and_get_links(self):
         # Create the object...
         bucket = self.client.bucket("bucket")
-        bucket.new("foo", 2) \
+        bucket.new_binary("test_store_and_get_links", '2') \
             .add_link(bucket.new("foo1")) \
             .add_link(bucket.new("foo2"), "tag") \
             .add_link(bucket.new("foo3"), "tag2!@#%^&*)") \
             .store()
-        obj = bucket.get("foo")
+        obj = bucket.get("test_store_and_get_links")
         links = obj.get_links()
         self.assertEqual(len(links), 3)
         for l in links:
             if (l.get_key() == "foo1"):
-                self.assertEqual(l.get_tag(), "")
-                next
-            if (l.get_key() == "foo2"):
+                self.assertEqual(l.get_tag(), "bucket")
+            elif (l.get_key() == "foo2"):
                 self.assertEqual(l.get_tag(), "tag")
-                next
-            if (l.get_key() == "foo3"):
+            elif (l.get_key() == "foo3"):
                 self.assertEqual(l.get_tag(), "tag2!@#%^&*)")
-                next
-            self.assertEqual("unknown key", l.get_key())
+            else:
+                self.assertEqual("unknown key", l.get_key())
 
     def test_link_walking(self):
         # Create the object...

--- a/riak/transports/http.py
+++ b/riak/transports/http.py
@@ -131,7 +131,7 @@ class RiakHttpTransport(RiakTransport) :
         else:
           self.check_http_code(response, [204])
           return None
-        
+
     def put_new(self, robj, w=None, dw=None, return_meta=True):
         """Put a new object into the Riak store, returning its (new) key."""
         # Construct the URL...
@@ -341,7 +341,8 @@ class RiakHttpTransport(RiakTransport) :
         """
         for linkHeader in linkHeaders.strip().split(','):
             linkHeader = linkHeader.strip()
-            matches = re.match("</([^/]+)/([^/]+)/([^/]+)>; ?riaktag=\"([^\']+)\"", linkHeader)
+            matches = re.match("</([^/]+)/([^/]+)/([^/]+)>; ?riaktag=\"([^\']+)\"", linkHeader) or \
+                re.match("</(buckets)/([^/]+)/keys/([^/]+)>; ?riaktag=\"([^\']+)\"", linkHeader)
             if matches is not None:
                 link = RiakLink(urllib.unquote_plus(matches.group(2)),
                                 urllib.unquote_plus(matches.group(3)),
@@ -393,7 +394,7 @@ class RiakHttpTransport(RiakTransport) :
 
     def post_request(self, uri=None, body=None, params=None, content_type="application/json"):
         uri = self.build_rest_path(prefix=uri, params=params)
-        return self.http_request('POST', uri, {'Content-Type': content_type}, body) 
+        return self.http_request('POST', uri, {'Content-Type': content_type}, body)
 
     # Utility functions used by Riak library.
 
@@ -449,7 +450,7 @@ class RiakHttpTransport(RiakTransport) :
                 headers[key] += ", " + rie.get_value()
             else:
                 headers[key] = rie.get_value()
-        
+
         return headers
 
     def http_request(self, method, uri, headers=None, body='') :


### PR DESCRIPTION
Without this links with characters that must be encoded are never decoded.

The unit test:
python -m unittest riak.tests.test_all.RiakHttpPoolTransportTestCase
did not check the content of the links, only that the right number
of links are returned so the "foo3" bucket with a link containing
special characters "tag2!@#%^&*)" results in the following when
retrieved "tag2%21%40%23%25%5E%26%2A%29"

Fixes Issue #75
