### PR TITLE
Fix issue #77 incorrectly formatted long headers.

### DIFF
--- a/riak/transports/http.py
+++ b/riak/transports/http.py
@@ -339,7 +339,7 @@ class RiakHttpTransport(RiakTransport) :
             for link in links:
                 header = self.to_link_header(link)
                 if len(current_header + header) > MAX_LINK_HEADER_SIZE:
-                    headers.setdefault('Link', []).append(current_header)
+                    headers.add('Link', current_header)
                     current_header = ''
 
                 if current_header != '': header = ', ' + header


### PR DESCRIPTION
Switched `append` to `add`

https://github.com/basho/riak-python-client/issues/77
