### PR TITLE
Temporary, simple fix for issue #32

### DIFF
--- a/riak/bucket.py
+++ b/riak/bucket.py
@@ -40,8 +40,8 @@ class RiakBucket(object):
         """
         try:
             if isinstance(name, basestring):
-                name.encode('ascii')
-        except UnicodeEncodeError:
+                name = name.encode('ascii')
+        except UnicodeError:
             raise TypeError('Unicode bucket names are not supported.')
 
         self._client = client
@@ -215,8 +215,8 @@ class RiakBucket(object):
         """
         try:
             if isinstance(data, basestring):
-                data.encode('ascii')
-        except UnicodeEncodeError:
+                data = data.encode('ascii')
+        except UnicodeError:
             raise TypeError('Unicode data values are not supported.')
 
         obj = RiakObject(self._client, self, key)

--- a/riak/mapreduce.py
+++ b/riak/mapreduce.py
@@ -322,8 +322,8 @@ class RiakMapReducePhase(object):
         """
         try:
             if isinstance(function, basestring):
-                function.encode('ascii')
-        except UnicodeEncodeError:
+                function = function.encode('ascii')
+        except UnicodeError:
             raise TypeError('Unicode encoded functions are not supported.')
 
         self._type = type

--- a/riak/riak_object.py
+++ b/riak/riak_object.py
@@ -41,8 +41,8 @@ class RiakObject(object):
         """
         try:
             if isinstance(key, basestring):
-                key.encode('ascii')
-        except UnicodeEncodeError:
+                key = key.encode('ascii')
+        except UnicodeError:
             raise TypeError('Unicode keys are not supported.')
 
         self._client = client


### PR DESCRIPTION
https://issues.basho.com/show_bug.cgi?id=649 has more details.
Eventually, we want to allow unicode keys and bucket names,
but we have yet to decide how to do that. Until we figure
that out, this patch will at least let us use the search
interface as long as we only use ascii-encodable keys and
bucket names.
