### PR TITLE
Protobuf transport now uses the ConnectionManager

### DIFF
--- a/riak/transports/pbc.py
+++ b/riak/transports/pbc.py
@@ -26,12 +26,12 @@ try:
 except ImportError:
     import simplejson as json
 
-from transport import RiakTransport
+from riak.transports.transport import RiakTransport
 from riak.metadata import *
 from riak.mapreduce import RiakMapReduce, RiakLink
 from riak import RiakError
 from riak.riak_index_entry import RiakIndexEntry
-from connection import SocketConnectionManager
+from riak.transports import connection
 
 try:
     import riakclient_pb2
@@ -71,6 +71,24 @@ RIAKC_RW_ALL = 4294967292
 RIAKC_RW_DEFAULT = 4294967291
 
 
+class SocketWithId(connection.Socket):
+    def __init__(self, host, port):
+        connection.Socket.__init__(self, host, port)
+        self.last_client_id = None
+
+    def maybe_connect(self):
+        # If we're going to establish a new connection, then reset the last
+        # client_id used on this connection.
+        if self.sock is None:
+            self.last_client_id = None
+
+            connection.Socket.maybe_connect(self)
+
+    def send(self, pkt):
+        self.sock.sendall(pkt)
+
+    def recv(self, want_len):
+        return self.sock.recv(want_len)
 
 
 class RiakPbcTransport(RiakTransport):
@@ -90,27 +108,19 @@ class RiakPbcTransport(RiakTransport):
         }
 
     # The ConnectionManager class that this transport prefers.
-    default_cm = SocketConnectionManager
+    default_cm = connection.cm_using(SocketWithId)
 
     def __init__(self, cm, client_id=None, **unused_options):
         """
         Construct a new RiakPbcTransport object.
-        @param string host - Hostname or IP address (default '127.0.0.1')
-        @param int port - Port number (default 8087)
         """
         if riakclient_pb2 is None:
             raise RiakError("this transport is not available (no protobuf)")
 
         super(RiakPbcTransport, self).__init__()
 
-        ### backwards compat. we don't use the ConnectionManager (yet).
-        host, port = cm.hostports[0]
-
         self._cm = cm
-        self._host = host
-        self._port = port
         self._client_id = client_id
-        self._sock = None
 
     def translate_rw_val(self, rw):
         val = self.rw_names.get(rw)
@@ -150,6 +160,18 @@ class RiakPbcTransport(RiakTransport):
 
         msg_code, resp = self.send_msg(MSG_CODE_SET_CLIENT_ID_REQ, req,
                                        MSG_CODE_SET_CLIENT_ID_RESP)
+
+        # Using different client_id values across connections is a bad idea
+        # since you never know which connection you might use for a given
+        # API call. Setting the client_id manually (rather than as part of
+        # the transport construction) can be error-prone since the connection
+        # could drop and be reinstated using self._client_id.
+        #
+        # To minimize the potential impact of variant client_id values across
+        # connections, we'll store this new client_id and use it for all
+        # future connections.
+        self._client_id = client_id
+
         return True
 
     def get(self, robj, r = None, vtag = None):
@@ -344,23 +366,10 @@ class RiakPbcTransport(RiakTransport):
         else:
             return result
 
-
-    def maybe_connect(self):
-        if self._sock is None:
-            self._sock = s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-
-            try:
-                s.connect((self._host, self._port))
-            except:
-                self._sock = None
-                raise
-
-            if self._client_id:
-                self.set_client_id(self._client_id)
-
     def send_msg_code(self, msg_code, expect):
-        self.send_pkt(struct.pack("!iB", 1, msg_code))
-        return self.recv_msg(expect)
+        with self._cm.withconn() as conn:
+            self.send_pkt(conn, struct.pack("!iB", 1, msg_code))
+            return self.recv_msg(conn, expect)
 
     def encode_msg(self, msg_code, msg):
         str = msg.SerializeToString()
@@ -369,26 +378,37 @@ class RiakPbcTransport(RiakTransport):
         return hdr + str
 
     def send_msg(self, msg_code, msg, expect):
-        self.send_pkt(self.encode_msg(msg_code, msg))
-        return self.recv_msg(expect)
+        with self._cm.withconn() as conn:
+            self.send_pkt(conn, self.encode_msg(msg_code, msg))
+            if msg_code == MSG_CODE_SET_CLIENT_ID_REQ:
+                conn.last_client_id = self._client_id
+            return self.recv_msg(conn, expect)
 
     def send_msg_multi(self, msg_code, msg, expect, handler):
-        self.send_pkt(self.encode_msg(msg_code, msg))
-        while True:
-            msg_code, resp = self.recv_msg(expect)
-            handler(resp)
-            if resp.HasField("done") and resp.done:
-                break
+        with self._cm.withconn() as conn:
+            self.send_pkt(conn, self.encode_msg(msg_code, msg))
+            while True:
+                msg_code, resp = self.recv_msg(conn, expect)
+                handler(resp)
+                if resp.HasField("done") and resp.done:
+                    break
 
-    def send_pkt(self, pkt):
-        self.maybe_connect()
-        sent_len = self._sock.send(pkt)
-        if sent_len != len(pkt):
-            raise RiakError("PB socket returned short write %d - expected %d"%\
-                            (sent_len, len(pkt)))
+    def send_pkt(self, conn, pkt):
+        conn.maybe_connect()
 
-    def recv_msg(self, expect):
-        self.recv_pkt()
+        # If the last client_id used on this connection is different than our
+        # client_id, then set a new ID on the connection.
+        if conn.last_client_id != self._client_id:
+            req = riakclient_pb2.RpbSetClientIdReq()
+            req.client_id = self._client_id
+            conn.send(self.encode_msg(MSG_CODE_SET_CLIENT_ID_REQ, req))
+            conn.last_client_id = self._client_id
+            self.recv_msg(conn, MSG_CODE_SET_CLIENT_ID_RESP)
+
+        conn.send(pkt)
+
+    def recv_msg(self, conn, expect):
+        self.recv_pkt(conn)
         msg_code, = struct.unpack("B", self._inbuf[:1])
         if msg_code == MSG_CODE_ERROR_RESP:
             msg = riakclient_pb2.RpbErrorResp()
@@ -431,10 +451,9 @@ class RiakPbcTransport(RiakTransport):
         return msg_code, msg
 
 
-    def recv_pkt(self):
-        nmsglen = self._sock.recv(4)
+    def recv_pkt(self, conn):
+        nmsglen = conn.recv(4)
         if len(nmsglen) != 4:
-            self._sock = None
             raise RiakError("Socket returned short packet length %d - expected 4"%\
                             len(nmsglen))
         msglen, = struct.unpack('!i', nmsglen)
@@ -442,7 +461,7 @@ class RiakPbcTransport(RiakTransport):
         self._inbuf = ''
         while len(self._inbuf) < msglen:
             want_len = min(8192, msglen - len(self._inbuf))
-            recv_buf = self._sock.recv(want_len)
+            recv_buf = conn.recv(want_len)
             if not recv_buf: break
             self._inbuf += recv_buf
         if len(self._inbuf) != self._inbuf_len:
@@ -536,7 +555,7 @@ class RiakPbcCachedTransport(RiakTransport):
     api = 2
 
     # The ConnectionManager class that this transport prefers.
-    default_cm = SocketConnectionManager
+    default_cm = connection.cm_using(SocketWithId)
 
     def __init__(self, cm,
                  client_id=None, maxsize=0, block=False, timeout=None,
@@ -545,11 +564,8 @@ class RiakPbcCachedTransport(RiakTransport):
             raise RiakError("this transport is not available (no protobuf)")
 
         ### backwards compat. we don't use the ConnectionManager (yet).
-        host, port = cm.hostports[0]
         self._cm = cm
 
-        self.host = host
-        self.port = port
         self.client_id = client_id
         self.block = block
         self.timeout = timeout


### PR DESCRIPTION
This series of commits gets the protobuf code to use the new ConnectionManager.

Note that it also includes my "factory-cm" branch. factory-cm can be quickly/easily merged in case this branch needs additional work before merging.

This passes all tests on my box, though I skip: luwak, search, indexes.

Note: there are architectural/design problems with Riak's protobuf interface using a connection-level (rather than per-request) client_id. This change attempts to apply some sanity, but may fight against clients trying to do Bad Things with variant client_id values.
