### PR TITLE
Add license headers

### DIFF
--- a/riak/transports/connection.py
+++ b/riak/transports/connection.py
@@ -1,6 +1,20 @@
-#
-# ### docco
-#
+"""
+Copyright 2011 Greg Stein <gstein@gmail.com>
+
+This file is provided to you under the Apache License,
+Version 2.0 (the "License"); you may not use this file
+except in compliance with the License.  You may obtain
+a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+"""
 
 import httplib
 import socket

--- a/riak/transports/monitor.py
+++ b/riak/transports/monitor.py
@@ -1,3 +1,21 @@
+"""
+Copyright 2011 Greg Stein <gstein@gmail.com>
+
+This file is provided to you under the Apache License,
+Version 2.0 (the "License"); you may not use this file
+except in compliance with the License.  You may obtain
+a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+"""
+
 import threading
 import time
 


### PR DESCRIPTION
A couple modules that I added did not have any license headers. This commit adds them.

Note: the licensing headers are generally incorrect within the client -- the set of copyright owners does not match what is typically listed (eg. Rusty, Justin, Jay). It would be more appropriate to move those into a NOTICE file (as defined by the Apache License in the LICENSE file). And alter the header to note multiple copyright owners exist, and to see the NOTICE file for more information. I would recommend switching to something similar as described on this page:
  http://www.apache.org/legal/src-headers.html
