### PR TITLE
Fix RiakObject.get_content_type() when content type not yet set.

### DIFF
--- a/riak/riak_object.py
+++ b/riak/riak_object.py
@@ -214,7 +214,7 @@ class RiakObject(object):
 
     def get_indexes(self, field = None):
         """
-        Get a list of the index entries for this object. If a field is provided, returns a list 
+        Get a list of the index entries for this object. If a field is provided, returns a list
 
         :param field: The index field.
         :type field: string or None
@@ -244,7 +244,13 @@ class RiakObject(object):
 
         :rtype: string
         """
-        return self._metadata[MD_CTYPE]
+        try:
+            return self._metadata[MD_CTYPE]
+        except KeyError:
+            if self._encode_data:
+                return "application/json"
+            else:
+                return "application/octet-stream"
 
     def set_content_type(self, content_type):
         """


### PR DESCRIPTION
This method currently raises a KeyError instead of appropriately returning the default content types.

As an example:

```
 import riak
 cl = riak.RiakClient()
 b = cl.bucket("test")
 obj = riak.RiakObject(cl, b, "foo")
 obj.set_encoded_data('{"a": 1}')
```

This will currently fail, but will work with the patch.
