### PR TITLE
Path conflict with PLATFORM_DATA_DIR in riak 1.x with TestServer

### DIFF
--- a/riak/test_server.py
+++ b/riak/test_server.py
@@ -200,7 +200,7 @@ class TestServer:
                     line = re.sub("(RUNNER_USER=)(.*)", r'\1', line)
                     line = re.sub("(RUNNER_LOG_DIR=)(.*)", r'\1%s' % self._temp_log, line)
                     line = re.sub("(PIPE_DIR=)(.*)", r'\1%s' % self._temp_pipe, line)
-                    line = re.sub("(PLATFORM_DATA_DIR=)(.*)", r'\1%s' % self.temp_dir)
+                    line = re.sub("(PLATFORM_DATA_DIR=)(.*)", r'\1%s' % self.temp_dir, line)
 
                     if string.strip(line) == "RUNNER_BASE_DIR=${RUNNER_SCRIPT_DIR%/*}":
                         line = "RUNNER_BASE_DIR=%s\n" % os.path.normpath(os.path.join(self.bin_dir, ".."))


### PR DESCRIPTION
Added an additional path change when rewriting the riak bin file as part of the TestServer initialization. In older versions of riak it simply wont be found.

This eliminates a problem with file ownership over ssl_distribution.args_file that the normal riak install owns.
