### PR TITLE
Fixes issue #124

### DIFF
--- a/riak/riak_object.py
+++ b/riak/riak_object.py
@@ -435,14 +435,15 @@ class RiakObject(object):
         :rtype: self
         """
         # Do the request...
-        r = self._bucket.get_r(r)
-        pr = self._bucket.get_pr(pr)
-        t = self._client.get_transport()
-        Result = t.get(self, r=r, pr=pr, vtag=vtag)
-
         self.clear()
-        if Result is not None:
-            self.populate(Result)
+        if self.get_key() is not None:
+            r = self._bucket.get_r(r)
+            pr = self._bucket.get_pr(pr)
+            t = self._client.get_transport()
+            Result = t.get(self, r=r, pr=pr, vtag=vtag)
+
+            if Result is not None:
+                self.populate(Result)
 
         return self
 

--- a/riak/tests/test_all.py
+++ b/riak/tests/test_all.py
@@ -203,6 +203,9 @@ class BaseTestCase(object):
         obj.reload()
         self.assertFalse(obj.exists())
 
+        self.assertFalse(bucket.get(None).exists())
+        self.assertRaises(TypeError, bucket.get(None).delete)
+
     def test_set_bucket_properties(self):
         bucket = self.client.bucket('bucket')
         # Test setting allow mult...
@@ -717,7 +720,7 @@ class BaseTestCase(object):
         self.assertEqual(1, len(result))
         self.assertEqual(3, len(bar.get_indexes()))
         self.assertEqual(2, len(bar.get_indexes('bar_int')))
-        
+
         # remove all indexes
         bar = bar.remove_indexes().store()
         result = self.client.index('indexbucket', 'bar_int', 1).run()

--- a/riak/transports/http.py
+++ b/riak/transports/http.py
@@ -157,6 +157,8 @@ class RiakHttpTransport(RiakTransport) :
     def delete(self, robj, rw=None, r = None, w = None, dw = None, pr = None, pw = None):
         # Construct the URL...
         params = {'rw' : rw, 'r': r, 'w': w, 'dw': dw, 'pr': pr, 'pw': pw}
+        if not isinstance(robj.get_key(), basestring):
+            raise TypeError("Object key must be a string!")
         url = self.build_rest_path(robj.get_bucket(), robj.get_key(),
                                    params=params)
         # TODO: Send vclock of robj if it exists


### PR DESCRIPTION
This is what I believe the best behaviour. The get(None) doesn't throw
an error, to be consistent.

However I'm not sure about delete(). To be completely consistent,
.delete() shouldn't throw any errors either, as the key of None doesn't
exists in the database anyway. However, the Pbc client currently throws
a TypeError (actually I would like it better if it didn't throw any
error and just moved on). Any input?
