### PR TITLE
Add crash_log to TestServer app_config.

### DIFF
--- a/riak/test_server.py
+++ b/riak/test_server.py
@@ -110,6 +110,7 @@ class TestServer:
 
         self.app_config["riak_core"]["ring_state_dir"] = os.path.join(self.temp_dir, "data", "ring")
         self.app_config["riak_core"]["platform_data_dir"] = self.temp_dir
+        self.app_config["lager"] = {"crash_log": os.path.join(self.temp_dir, "log", "crash.log")}
 
     def prepare(self):
         if not self._prepared:


### PR DESCRIPTION
This patch adds a lager configuration specifying a crash log to the test server. It's useful for figuring out why your test server isn't starting.
