### PR TITLE
Fix doc of index method

### DIFF
--- a/riak/mapreduce.py
+++ b/riak/mapreduce.py
@@ -107,7 +107,9 @@ class RiakMapReduce(object):
         Begin a map/reduce operation using a Secondary Index
         query.
         @param bucket - The bucket over which to perform the search.
-        @param query - The search query.
+        @param index - The index to use for query
+        @param startkey - The start key of index range
+        @param endkey - The end key of index range or blank
         """
         self._input_mode = 'query'
 


### PR DESCRIPTION
The doc of index method seemd to be copied from another method. Changed the doc of the params to match the method signature.
