### PR TITLE
Fix bug where http_status is used instead of http_code

### DIFF
--- a/riak/transports/http.py
+++ b/riak/transports/http.py
@@ -132,7 +132,7 @@ class RiakHttpTransport(RiakTransport):
         """
         response = self.http_request('GET', '/',
                                      {'Accept': 'application/json'})
-        if response[0]['http_status'] is 200:
+        if response[0]['http_code'] is 200:
             return json.loads(response[1])
         else:
             return {}


### PR DESCRIPTION
We found a bug in environment and tracked it down to the difference between riak client 1.4 and 1.5.

It looks like it's checking for the non-existent http_status field, which should be (as is used in every other place in the file) http_code.
