### PR TITLE
Added simple ssl support to http transport

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,8 +97,15 @@ no arguments are needed::
 
     client = riak.RiakClient()
 
-The constructor also configuration options such as ``host``, ``port`` &
+The constructor also configuration options such as ``host``, ``port``, ``ssl`` &
 ``prefix``. Please refer to the :doc:`client` documentation for full details.
+
+If your Riak cluster is ssl enabled you can access it via HTTPS by setting
+the ``ssl`` argument to ``True``::
+
+    import riak
+
+    client = riak.RiakClient(port=8091, ssl=True)
 
 To use the Protocol Buffers interface::
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -61,8 +61,15 @@ no arguments are needed::
 
     client = riak.RiakClient()
 
-The constructor also configuration options such as ``host``, ``port`` &
+The constructor also configuration options such as ``host``, ``port``, ``ssl`` &
 ``prefix``. Please refer to the :doc:`client` documentation for full details.
+
+If your Riak cluster is ssl enabled you can access it via HTTPS by setting
+the ``ssl`` argument to ``True``::
+
+    import riak
+
+        client = riak.RiakClient(port=8091, ssl=True)
 
 To use the Protocol Buffers interface::
 

--- a/riak/client.py
+++ b/riak/client.py
@@ -27,6 +27,7 @@ from riak.bucket import RiakBucket
 from riak.mapreduce import RiakMapReduce
 from riak.search import RiakSearch
 from riak.transports import RiakHttpTransport
+from riak.transports import RiakHttpsTransport
 from riak.util import deprecated
 
 
@@ -37,7 +38,7 @@ class RiakClient(object):
     connection, and the ``RiakClient`` object is extremely lightweight.
     """
     def __init__(self, host='127.0.0.1', port=8098, prefix='riak',
-                 mapred_prefix='mapred', transport_class=None,
+                 mapred_prefix='mapred', ssl=False, transport_class=None,
                  client_id=None, solr_transport_class=None,
                  transport_options=None):
         """
@@ -62,7 +63,10 @@ class RiakClient(object):
         :type transport_options: dict
         """
         if transport_class is None:
-            transport_class = RiakHttpTransport
+            if ssl is True:
+                transport_class = RiakHttpsTransport
+            else:
+                transport_class = RiakHttpTransport
 
         api = getattr(transport_class, 'api', 1)
         if api >= 2:

--- a/riak/transports/__init__.py
+++ b/riak/transports/__init__.py
@@ -1,2 +1,3 @@
 from http import RiakHttpTransport
+from http import RiakHttpsTransport
 from pbc import RiakPbcTransport

--- a/riak/transports/connection.py
+++ b/riak/transports/connection.py
@@ -185,6 +185,7 @@ def cm_using(connection_class):
     return functools.partial(FactoryConnectionManager, connection_class)
 
 HTTPConnectionManager = cm_using(httplib.HTTPConnection)
+HTTPSConnectionManager = cm_using(httplib.HTTPSConnection)
 SocketConnectionManager = cm_using(Socket)
 
 

--- a/riak/transports/http.py
+++ b/riak/transports/http.py
@@ -38,6 +38,7 @@ from riak import RiakError
 from riak.riak_index_entry import RiakIndexEntry
 from riak.multidict import MultiDict
 from connection import HTTPConnectionManager
+from connection import HTTPSConnectionManager
 import riak.util
 from xml.etree import ElementTree
 
@@ -680,6 +681,16 @@ class RiakHttpTransport(RiakTransport):
             else:
                 retVal[key] = value
         return retVal
+
+
+class RiakHttpsTransport(RiakHttpTransport):
+    """
+    The RiakHttpsTransport object holds information necessary to
+    connect to a Riak cluster running with SSL enabled.
+    """
+
+    # The ConnectionManager class that this transport prefers.
+    default_cm = HTTPSConnectionManager
 
 
 class XMLSearchResult(object):


### PR DESCRIPTION
I wanted the ability to use the existing http transport, but toggle it to use https with just a flag in the constructor. This is similar to how other clients (ruby) work.

```
client = RiakClient(host=..., port=..., ssl=True)
```

On the back end there is a new class, `RiakHttpsTransport`, that is just a sub class of `RiakHttpTransport` where the `default_cm` is overridden to ultimately use `httplib.HTTPSConnection`. 

Again, it's a simple solution, but I've tested it and it works just fine on our SSL enabled Riak clusters. Very little existing code was touched, so risk is minimal. Docs (README and tutorial) have been updated to reflect the new feature.

Salud,

./j 

**EDIT**

The travis build failed, but it seems for reasons I cannot account for. Looks like riak didn't get installed properly on the build slaves:

```
3 $ cd ~/builds
4 $ export SKIP_LUWAK=1
5 $ sudo service riak start
6 riak: unrecognized service
```

and:

```
52 Finished processing dependencies for riak==1.5.0
53 $ sudo search-cmd install searchbucket
54 sudo: search-cmd: command not found
55
56
57 before_script: 'sudo search-cmd install searchbucket' returned false.
```
