### PR TITLE
add list-consuming convenience function for mr.add

### DIFF
--- a/riak/mapreduce.py
+++ b/riak/mapreduce.py
@@ -83,14 +83,14 @@ class RiakMapReduce(object):
 
     def add_key_filters(self, key_filters):
         if self._input_mode == 'query':
-            raise Exception('Key filters are not supported in a query.')
+            raise ValueError('Key filters are not supported in a query.')
 
         self._key_filters.extend(key_filters)
         return self
 
     def add_key_filter(self, *args):
         if self._input_mode == 'query':
-            raise Exception('Key filters are not supported in a query.')
+            raise ValueError('Key filters are not supported in a query.')
 
         self._key_filters.append(args)
         return self

--- a/riak/tests/test_mapreduce.py
+++ b/riak/tests/test_mapreduce.py
@@ -83,6 +83,27 @@ class ErlangMapReduceTests(object):
             .run()
         self.assertEqual(len(result), 2)
 
+    def test_client_exceptional_paths(self):
+        bucket = self.client.bucket('bucket')
+        bucket.new("foo", 2).store()
+        bucket.new("bar", 2).store()
+        bucket.new("baz", 4).store()
+
+        #adding a b-key pair to a bucket input
+        with self.assertRaises(ValueError):
+            mr = self.client.add('bucket')
+            mr.add('bucket', 'bar')
+
+        #adding a b-key pair to a query input
+        with self.assertRaises(ValueError):
+            mr = self.client.search('bucket', 'fleh')
+            mr.add('bucket', 'bar')
+
+        #adding a key filter to a query input
+        with self.assertRaises(ValueError):
+            mr = self.client.search('bucket', 'fleh')
+            mr.add_key_filter("tokenize", "-", 1)
+ 
 
 class JSMapReduceTests(object):
     def test_javascript_source_map(self):


### PR DESCRIPTION
add the ability to pass in a non-string iterable to specify a list of keys in a bucket to fetch via mapreduce.

This should address issue @bconway's issue #123.  An alternative usage would be to accept an iterable as the first argument and require it to be a list of [(bucket, key)], but there are so many ways to format the input (list of tuples, list of lists, a dict, etc), that I thought the way I did it was the simplest.
