### PR TITLE
Allow strfun erlang functions in m/r

### DIFF
--- a/riak/mapreduce.py
+++ b/riak/mapreduce.py
@@ -359,6 +359,9 @@ class RiakMapReducePhase(object):
             stepdef['module'] = self._function[0]
             stepdef['function'] = self._function[1]
 
+        elif (self._language == 'erlang' and isinstance(self._function, str)):
+            stepdef['source'] = self._function
+
         return {self._type: stepdef}
 
 


### PR DESCRIPTION
With {allow_strfun, true} in app.config/riak_kv, it's possible to send ad-hoc erlang functions as map or reduce phases. This patch allows you to do so.
