### PR TITLE
Loosen the version restriction if Riak is on a prerelease version.

### DIFF
--- a/riak/tests/test_feature_detection.py
+++ b/riak/tests/test_feature_detection.py
@@ -86,5 +86,16 @@ class FeatureDetectionTest(unittest.TestCase):
         self.assertTrue(t.tombstone_vclocks())
         self.assertTrue(t.pb_head())
 
+    def test_12_loose(self):
+        t = DummyTransport("1.2.1p3")
+        self.assertTrue(t.phaseless_mapred())
+        self.assertTrue(t.pb_indexes())
+        self.assertTrue(t.pb_search())
+        self.assertTrue(t.pb_conditionals())
+        self.assertTrue(t.quorum_controls())
+        self.assertTrue(t.tombstone_vclocks())
+        self.assertTrue(t.pb_head())
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/riak/transports/feature_detect.py
+++ b/riak/transports/feature_detect.py
@@ -16,14 +16,14 @@ specific language governing permissions and limitations
 under the License.
 """
 
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 from riak.util import lazy_property
 
 
 versions = {
-    1: StrictVersion("1.0.0"),
-    1.1: StrictVersion("1.1.0"),
-    1.2: StrictVersion("1.2.0")
+    1: LooseVersion("1.0.0"),
+    1.1: LooseVersion("1.1.0"),
+    1.2: LooseVersion("1.2.0")
     }
 
 
@@ -92,4 +92,4 @@ class FeatureDetection(object):
 
     @lazy_property
     def server_version(self):
-        return StrictVersion(self._server_version())
+        return LooseVersion(self._server_version())


### PR DESCRIPTION
This alleviates errors that occur with feature detection, since Riak doesn't follow Python's versioning scheme defined in the `StrictVersion` class.  Specifically, those currently occurring in our `riak_test` suite will pass.
