### PR TITLE
FIxes type in BaseTestCase.create_client

### DIFF
--- a/riak/tests/test_all.py
+++ b/riak/tests/test_all.py
@@ -64,8 +64,8 @@ class BaseTestCase(object):
         host = host or self.host
         port = port or self.port
         transport_class = transport_class or self.transport_class
-        return RiakClient(self.host, self.port,
-                          transport_class=self.transport_class)
+        return RiakClient(host, port,
+                          transport_class=transport_class)
 
     def setUp(self):
         self.client = self.create_client()


### PR DESCRIPTION
In create_client is checks the args then sets the host, port, and transport to use but then uses the attributes anyways.
