### PR TITLE
Got rid of apply func calls

### DIFF
--- a/riak/mapreduce.py
+++ b/riak/mapreduce.py
@@ -769,7 +769,7 @@ class RiakMapReduceChain(object):
         :rtype: :class:`RiakMapReduce`
         """
         mr = RiakMapReduce(self)
-        return apply(mr.add, args)
+        return mr.add(*args)
 
     def search(self, *args):
         """
@@ -781,7 +781,7 @@ class RiakMapReduceChain(object):
         :rtype: :class:`RiakMapReduce`
         """
         mr = RiakMapReduce(self)
-        return apply(mr.search, args)
+        return mr.search(*args)
 
     def index(self, *args):
         """
@@ -791,7 +791,7 @@ class RiakMapReduceChain(object):
         :rtype: :class:`RiakMapReduce`
         """
         mr = RiakMapReduce(self)
-        return apply(mr.index, args)
+        return mr.index(*args)
 
     def link(self, *args):
         """
@@ -801,7 +801,7 @@ class RiakMapReduceChain(object):
         :rtype: :class:`RiakMapReduce`
         """
         mr = RiakMapReduce(self)
-        return apply(mr.link, args)
+        return mr.link(*args)
 
     def map(self, *args):
         """
@@ -811,7 +811,7 @@ class RiakMapReduceChain(object):
         :rtype: :class:`RiakMapReduce`
         """
         mr = RiakMapReduce(self)
-        return apply(mr.map, args)
+        return mr.map(*args)
 
     def reduce(self, *args):
         """
@@ -821,7 +821,7 @@ class RiakMapReduceChain(object):
         :rtype: :class:`RiakMapReduce`
         """
         mr = RiakMapReduce(self)
-        return apply(mr.reduce, args)
+        return mr.reduce(*args)
 
 from riak.riak_object import RiakObject
 from riak.bucket import RiakBucket

--- a/riak/riak_object.py
+++ b/riak/riak_object.py
@@ -573,7 +573,7 @@ class RiakObject(object):
         """
         mr = RiakMapReduce(self.client)
         mr.add(self.bucket.name, self.key)
-        return apply(mr.add, args)
+        return mr.add(*args)
 
     def link(self, *args):
         """
@@ -584,7 +584,7 @@ class RiakObject(object):
         """
         mr = RiakMapReduce(self.client)
         mr.add(self.bucket.name, self.key)
-        return apply(mr.link, args)
+        return mr.link(*args)
 
     def map(self, *args):
         """
@@ -595,9 +595,9 @@ class RiakObject(object):
         """
         mr = RiakMapReduce(self.client)
         mr.add(self.bucket.name, self.key)
-        return apply(mr.map, args)
+        return mr.map(*args)
 
-    def reduce(self, params):
+    def reduce(self, *args):
         """
         Start assembling a Map/Reduce operation.
         A shortcut for :func:`RiakMapReduce.reduce`.
@@ -606,4 +606,4 @@ class RiakObject(object):
         """
         mr = RiakMapReduce(self.client)
         mr.add(self.bucket.name, self.key)
-        return apply(mr.reduce, params)
+        return mr.reduce(*args)


### PR DESCRIPTION
Got rid of deprecated calls and used modern approach. Also fixed what
seems like a type in `RiakObject.reduce`, it should be `*args` rather
than just `param`

Anything else that's deprecated that should be gotten rid of?
