### PR TITLE
Switching JSON encoding to UTF-8.

### DIFF
--- a/riak/client/__init__.py
+++ b/riak/client/__init__.py
@@ -38,6 +38,14 @@ from riak.util import deprecateQuorumAccessors
 from riak.util import lazy_property
 
 
+def default_encoder(obj):
+    """
+    Default encoder for JSON datatypes, which returns UTF-8 encoded
+    json instead of the default bloated \uXXXX escaped ASCII strings.
+    """
+    return json.dumps(obj, ensure_ascii=False).encode("utf-8")
+
+
 @deprecateQuorumAccessors
 class RiakClient(RiakMapReduceChain, RiakClientOperations):
     """
@@ -91,8 +99,8 @@ class RiakClient(RiakMapReduceChain, RiakClientOperations):
         self._http_pool = RiakHttpPool(self, **transport_options)
         self._pb_pool = RiakPbcPool(self, **transport_options)
 
-        self._encoders = {'application/json': json.dumps,
-                          'text/json': json.dumps}
+        self._encoders = {'application/json': default_encoder,
+                          'text/json': default_encoder}
         self._decoders = {'application/json': json.loads,
                           'text/json': json.loads}
         self._buckets = WeakValueDictionary()


### PR DESCRIPTION
By default, python's JSON encoder will escape all non-ASCII
characters, using a sequence of 6 bytes, for the sake of legacy
non-UTF-8 compatible clients. This is a significant overhead in the
case of non-ASCII string and can be reduced by using a modern encoding.

I saw no side effects from this change so far and the Ruby client is already encoding things properly. Discussion about this can be found here: http://lists.basho.com/pipermail/riak-users_lists.basho.com/2013-February/010908.html
