### PR TITLE
Fixed typo for __ne__

### DIFF
--- a/riak/riak_object.py
+++ b/riak/riak_object.py
@@ -74,7 +74,7 @@ class RiakObject(object):
         else:
             return False
 
-    def __nq__(self, other):
+    def __ne__(self, other):
         if isinstance(other, self.__class__):
             return hash(self) != hash(other)
         else:


### PR DESCRIPTION
We could probably also refactor `__ne__` to call `__eq__`
