### PR TITLE
Changed 'localhost' to '127.0.0.1' in riak/tests/test_all.py

### DIFF
--- a/riak/tests/test_all.py
+++ b/riak/tests/test_all.py
@@ -30,7 +30,7 @@ try:
 except ImportError:
     HAVE_PROTO = False
 
-HOST = os.environ.get('RIAK_TEST_HOST', 'localhost')
+HOST = os.environ.get('RIAK_TEST_HOST', '127.0.0.1')
 
 PB_HOST = os.environ.get('RIAK_TEST_PB_HOST', HOST)
 PB_PORT = int(os.environ.get('RIAK_TEST_PB_PORT', '8087'))


### PR DESCRIPTION
Riak default host address is 127.0.0.1 in IPv4. This should be explicitly stated to prevent confusion of resolving the name "localhost" in IPv4/IPv6 dual-stack hosts.

Also see https://github.com/basho/riak-python-client/issues/219 
