### PR TITLE
Update riak/tests/test_all.py so that non-local address test will be properly executed

### DIFF
--- a/riak/tests/test_all.py
+++ b/riak/tests/test_all.py
@@ -57,7 +57,7 @@ def setUpModule():
     global testrun_search_bucket, testrun_props_bucket, \
         testrun_sibs_bucket
 
-    c = RiakClient(transport='http', http_port=HTTP_PORT)
+    c = RiakClient(transport='http', host=HTTP_HOST, http_port=HTTP_PORT)
 
     testrun_props_bucket = 'propsbucket'
     testrun_sibs_bucket = 'sibsbucket'
@@ -70,7 +70,7 @@ def setUpModule():
 
 
 def tearDownModule():
-    c = RiakClient(transport='http', http_port=HTTP_PORT)
+    c = RiakClient(transport='http', host=HTTP_HOST, http_port=HTTP_PORT)
     if not int(os.environ.get('SKIP_SEARCH', '0')):
         b = c.bucket(testrun_search_bucket)
         b.clear_properties()


### PR DESCRIPTION
- Explicitly set http=HTTP_HOST to riak.RiakClient()
  So that setUpModule() and tearDownModule() will succeed
  to non-localhost addresses when running `python setup.py test`
