### PR TITLE
Issue #228: Do not allow the creation of an empty RiakObject key

### DIFF
--- a/riak/riak_object.py
+++ b/riak/riak_object.py
@@ -17,7 +17,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 """
-import copy
 from riak import RiakError
 from riak.util import deprecated
 


### PR DESCRIPTION
Simply checking in new() for an empty key name.  Covers both PBC and HTTP.
