### PR TITLE
Fix issue with reloading deleted objects over PBC.

### DIFF
--- a/riak/tests/test_kv.py
+++ b/riak/tests/test_kv.py
@@ -206,7 +206,7 @@ class BasicKVTests(object):
         obj.store()
 
         bucket.delete(self.key_name)
-        obj = bucket.get(self.key_name)
+        obj.reload()
         self.assertFalse(obj.exists)
 
     def test_set_bucket_properties(self):

--- a/riak/transports/pbc/transport.py
+++ b/riak/transports/pbc/transport.py
@@ -127,6 +127,7 @@ class RiakPbcTransport(RiakTransport, RiakPbcConnection, RiakPbcCodec):
                 ret.siblings = contents[:]
             return ret
         else:
+            old_obj.exists = False
             return old_obj
 
     def get(self, robj, r=None, pr=None, vtag=None):


### PR DESCRIPTION
- Reinstated @shuhaowu's obj.reload() in bucket delete test.
- Set obj.exists to False if there are no contents, resolving reload
  problem.
