### PR TITLE
Speed up test server start

### DIFF
--- a/riak/test_server.py
+++ b/riak/test_server.py
@@ -199,7 +199,7 @@ class TestServer(object):
         prompted = False
         buffer = ""
         while not prompted:
-            line = self._server.stdout.read(1)
+            line = self._server.stdout.readline()
             if len(line) > 0:
                 buffer += line
             if re.search(r"\(%s\)\d+>" % self.vm_args["-name"], buffer):


### PR DESCRIPTION
- Seemed to slow down with riak 1.3 which seems to be because of much
  more text output when starting
- wait_for_erlang_prompt was reading one character at a time and running
  a long regex against the output which was causing the output of riak
  console to stall
- Changed to read a line at a time speeds up from 34 seconds to 2.4 on
  my system
