### PR TITLE
Fixed RiakHttpTransport with non-ascii streams

### DIFF
--- a/riak/tests/test_kv.py
+++ b/riak/tests/test_kv.py
@@ -70,6 +70,24 @@ class BasicKVTests(object):
         obj2 = bucket.get('baz')
         self.assertEqual(obj2.data, rand)
 
+    def test_store_obj_with_unicode(self):
+        bucket = self.client.bucket(self.bucket_name)
+        data = {u'føø': u'éå'}
+        obj = bucket.new('foo', data)
+        obj.store()
+        obj = bucket.get('foo')
+        self.assertEqual(obj.data, data)
+
+    def test_store_unicode_string(self):
+        bucket = self.client.bucket(self.bucket_name)
+        data = u"some unicode data: \u00c6"
+        obj = bucket.new(self.key_name, encoded_data=data.encode('utf-8'),
+                         content_type='text/plain')
+        obj.charset = 'utf-8'
+        obj.store()
+        obj2 = bucket.get(self.key_name)
+        self.assertEqual(data, obj2.encoded_data.decode('utf-8'))
+
     def test_generate_key(self):
         # Ensure that Riak generates a random key when
         # the key passed to bucket.new() is None.

--- a/riak/transports/http/transport.py
+++ b/riak/transports/http/transport.py
@@ -126,7 +126,7 @@ class RiakHttpTransport(RiakHttpConnection, RiakHttpResources, RiakHttpCodec,
         params = {'returnbody': return_body, 'w': w, 'dw': dw, 'pw': pw}
         url = self.object_path(robj.bucket.name, robj.key, **params)
         headers = self._build_put_headers(robj, if_none_match=if_none_match)
-        content = robj.encoded_data
+        content = bytearray(robj.encoded_data)
 
         if robj.key is None:
             expect = [201]


### PR DESCRIPTION
- Encoded data that has octets outside the 128 byte range fail in
  python's httplib
- Using a bytearray for the message body causes the entire stream to be
  converted to a bytearray when a str object is added to it and the
  message is transported correctly
- Added two tests one with unicode data in a json object and one unicode
  data in a string
