### PR TITLE
Install Riak on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,3 @@ script: ./setup.py test
 before_script: sudo /usr/sbin/search-cmd install searchbucket
 notifications:
   email: clients@basho.com
-# services:
-#   - riak


### PR DESCRIPTION
This is important so that we can test against the latest released version of Riak. It uses the directions found on the [Riak documentation](http://docs.basho.com/riak/latest/tutorials/installation/Installing-on-Debian-and-Ubuntu/#Installing-From-Apt-Get).
