### PR TITLE
Fixes ConflictError on non-existent objects

### DIFF
--- a/riak/riak_object.py
+++ b/riak/riak_object.py
@@ -39,6 +39,8 @@ def content_property(name, doc=None):
         setattr(self.siblings[0], name, value)
 
     def _getter(self):
+        if len(self.siblings) == 0:
+            return
         if len(self.siblings) != 1:
             raise ConflictError()
         return getattr(self.siblings[0], name)

--- a/riak/tests/test_kv.py
+++ b/riak/tests/test_kv.py
@@ -220,6 +220,8 @@ class BasicKVTests(object):
         bucket = self.client.bucket(self.bucket_name)
         obj = bucket.get(self.key_name)
         self.assertFalse(obj.exists)
+        # Object with no siblings should not raise the ConflictError
+        self.assertIsNone(obj.data)
 
     def test_delete(self):
         bucket = self.client.bucket(self.bucket_name)


### PR DESCRIPTION
The recent refactoring altered the behavior of RiakObject in such a way that reading of non-existent key raises ConflictError. This seems to be a bit wrong since empty object has no conflicting siblings, in fact such an object has no siblings at all.

``` python
>>> obj = riak_client.bucket('a_bucket').get('nonexistent')
>>> print obj.data
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "riak/riak_object.py", line 45, in _getter
    raise ConflictError()
riak.ConflictError: 'Object in conflict'   # wrong
```

Proposed patch makes the RiakObject behave in the same way as before, returning None on attempt to read the empty data:

``` python
>>> obj = riak_client.bucket('a_bucket').get('nonexistent')
>>> print obj.data
None
```

One can suggest to raise a specialized exception in case of empty siblings list - seems OK to me too.
