### PR TITLE
Fix deprecated code path usage in RiakBucket.search()

### DIFF
--- a/riak/bucket.py
+++ b/riak/bucket.py
@@ -443,7 +443,7 @@ class RiakBucket(object):
         :meth:`RiakClient.fulltext_search()
         <riak.client.RiakClient.fulltext_search>` for more details.
         """
-        return self._client.solr.search(self.name, query, **params)
+        return self._client.fulltext_search(self.name, query, **params)
 
     def get_index(self, index, startkey, endkey=None, return_terms=None,
                   max_results=None, continuation=None):


### PR DESCRIPTION
The two expressions are equivalent, except the original one is using deprecated API. Internal usage of publicly deprecated API should be avoided in general, plus it's causing annoying `UserWarning`s when the user is not at fault. So here's a patch fixing that.

Thanks for your work making the 2.0 release more usable and Pythonic!
