### PR TITLE
Add configurable operation retries

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -44,23 +44,32 @@ Client objects
       client will connect to. It is best not to modify this property
       directly, as it is not thread-safe.
 
-   .. attribute:: RETRY_COUNT
-
-      The maximum number of times to retry requests where it is
-      permitted, default is 3. Retries will attempt to select nodes
-      with better error rates, excluding nodes where the request
-      failed.
-
 ^^^^^
 Nodes
 ^^^^^
 
-The ``nodes`` attribute of ``RiakClient`` objects is a list of
-``RiakNode`` objects. If you include multiple host specifications in
-the ``RiakClient`` constructor, they will be turned into this type.
+The :attr:`nodes <RiakClient.nodes>` attribute of ``RiakClient`` objects is
+a list of ``RiakNode`` objects. If you include multiple host
+specifications in the ``RiakClient`` constructor, they will be turned
+into this type.
 
 .. autoclass:: riak.node.RiakNode
    :members:
+
+^^^^^^^^^^^
+Retry logic
+^^^^^^^^^^^
+
+Some operations that fail because of network errors or Riak node
+failure may be safely retried on another node, and the client will do
+so automatically. The items below can be used to configure this
+behavior.
+
+.. autoattribute:: RiakClient.retries
+
+.. automethod:: RiakClient.retry_count
+
+.. autodata:: riak.client.transport.DEFAULT_RETRY_COUNT
 
 -----------------------
 Client-level Operations

--- a/riak/client/operations.py
+++ b/riak/client/operations.py
@@ -42,7 +42,7 @@ class RiakClientOperations(RiakClientTransport):
         .. warning:: Do not use this in production, as it requires
            traversing through all keys stored in a cluster.
 
-        .. note:: This request is automatically retried :attr:`RETRY_COUNT`
+        .. note:: This request is automatically retried :attr:`retries`
            times if it fails due to network error.
 
         :param timeout: a timeout value in milliseconds
@@ -84,7 +84,7 @@ class RiakClientOperations(RiakClientTransport):
 
         Check if the Riak server for this ``RiakClient`` instance is alive.
 
-        .. note:: This request is automatically retried :attr:`RETRY_COUNT`
+        .. note:: This request is automatically retried :attr:`retries`
            times if it fails due to network error.
 
         :rtype: boolean
@@ -103,7 +103,7 @@ class RiakClientOperations(RiakClientTransport):
 
         Queries a secondary index, returning matching keys.
 
-        .. note:: This request is automatically retried :attr:`RETRY_COUNT`
+        .. note:: This request is automatically retried :attr:`retries`
            times if it fails due to network error.
 
         :param bucket: the bucket whose index will be queried
@@ -190,7 +190,7 @@ class RiakClientOperations(RiakClientTransport):
 
         Fetches bucket properties for the given bucket.
 
-        .. note:: This request is automatically retried :attr:`RETRY_COUNT`
+        .. note:: This request is automatically retried :attr:`retries`
            times if it fails due to network error.
 
         :param bucket: the bucket whose properties will be fetched
@@ -206,7 +206,7 @@ class RiakClientOperations(RiakClientTransport):
 
         Sets bucket properties for the given bucket.
 
-        .. note:: This request is automatically retried :attr:`RETRY_COUNT`
+        .. note:: This request is automatically retried :attr:`retries`
            times if it fails due to network error.
 
         :param bucket: the bucket whose properties will be set
@@ -223,7 +223,7 @@ class RiakClientOperations(RiakClientTransport):
 
         Resets bucket properties for the given bucket.
 
-        .. note:: This request is automatically retried :attr:`RETRY_COUNT`
+        .. note:: This request is automatically retried :attr:`retries`
            times if it fails due to network error.
 
         :param bucket: the bucket whose properties will be set
@@ -238,7 +238,7 @@ class RiakClientOperations(RiakClientTransport):
 
         Lists all keys in a bucket.
 
-        .. note:: This request is automatically retried :attr:`RETRY_COUNT`
+        .. note:: This request is automatically retried :attr:`retries`
            times if it fails due to network error.
 
         :param bucket: the bucket whose properties will be set
@@ -280,7 +280,7 @@ class RiakClientOperations(RiakClientTransport):
 
         Stores an object in the Riak cluster.
 
-        .. note:: This request is automatically retried :attr:`RETRY_COUNT`
+        .. note:: This request is automatically retried :attr:`retries`
            times if it fails due to network error.
 
         :param robj: the object to store
@@ -313,7 +313,7 @@ class RiakClientOperations(RiakClientTransport):
 
         Fetches the contents of a Riak object.
 
-        .. note:: This request is automatically retried :attr:`RETRY_COUNT`
+        .. note:: This request is automatically retried :attr:`retries`
            times if it fails due to network error.
 
         :param robj: the object to fetch
@@ -341,7 +341,7 @@ class RiakClientOperations(RiakClientTransport):
 
         Deletes an object from Riak.
 
-        .. note:: This request is automatically retried :attr:`RETRY_COUNT`
+        .. note:: This request is automatically retried :attr:`retries`
            times if it fails due to network error.
 
         :param robj: the object to delete
@@ -372,7 +372,7 @@ class RiakClientOperations(RiakClientTransport):
 
         Executes a MapReduce query.
 
-        .. note:: This request is automatically retried :attr:`RETRY_COUNT`
+        .. note:: This request is automatically retried :attr:`retries`
            times if it fails due to network error.
 
         :param inputs: the input list/structure
@@ -494,7 +494,7 @@ class RiakClientOperations(RiakClientTransport):
 
         Performs a full-text search query.
 
-        .. note:: This request is automatically retried :attr:`RETRY_COUNT`
+        .. note:: This request is automatically retried :attr:`retries`
            times if it fails due to network error.
 
         :param index: the bucket/index to search over
@@ -514,7 +514,7 @@ class RiakClientOperations(RiakClientTransport):
         Adds documents to the full-text index.
 
         .. note:: This request is automatically retried
-           :attr:`RETRY_COUNT` times if it fails due to network error.
+           :attr:`retries` times if it fails due to network error.
            Only HTTP will be used for this request.
 
         :param index: the bucket/index in which to index these docs
@@ -532,7 +532,7 @@ class RiakClientOperations(RiakClientTransport):
         Removes documents from the full-text index.
 
         .. note:: This request is automatically retried
-           :attr:`RETRY_COUNT` times if it fails due to network error.
+           :attr:`retries` times if it fails due to network error.
            Only HTTP will be used for this request.
 
         :param index: the bucket/index from which to delete
@@ -566,7 +566,7 @@ class RiakClientOperations(RiakClientTransport):
 
         Gets the value of a counter.
 
-        .. note:: This request is automatically retried :attr:`RETRY_COUNT`
+        .. note:: This request is automatically retried :attr:`retries`
            times if it fails due to network error.
 
         :param bucket: the bucket of the counter


### PR DESCRIPTION
- The original retry count has become a module constant
  `DEFAULT_RETRY_COUNT`.
- The configured number of retries is a thread-local, meaning that it
  remains safe even in threaded applications. It can be set using
  `client.retries` or for the scope of with statement invoking
  `client.retry_count` with the desired number of retries as the only
  argument.
- Added a section to the docs about the retry logic.

cc @martinsumner
