### PR TITLE
Added default_headers attribute to RiakHttpConnection

### DIFF
--- a/riak/transports/http/connection.py
+++ b/riak/transports/http/connection.py
@@ -23,6 +23,8 @@ class RiakHttpConnection(object):
     """
     Connection and low-level request methods for RiakHttpTransport.
     """
+    def __init__(self, default_headers=None):
+        self.default_headers = default_headers or {}
 
     def _request(self, method, uri, headers={}, body='', stream=False):
         """
@@ -33,6 +35,7 @@ class RiakHttpConnection(object):
         response = None
         headers.setdefault('Accept',
                            'multipart/mixed, application/json, */*;q=0.5')
+        headers.update(self.default_headers)
         try:
             self._connection.request(method, uri, body, headers)
             response = self._connection.getresponse()

--- a/riak/transports/http/transport.py
+++ b/riak/transports/http/transport.py
@@ -55,7 +55,7 @@ class RiakHttpTransport(RiakHttpConnection, RiakHttpResources, RiakHttpCodec,
         """
         Construct a new HTTP connection to Riak.
         """
-        super(RiakHttpTransport, self).__init__()
+        super(RiakHttpTransport, self).__init__(**unused_options)
 
         self._client = client
         self._node = node


### PR DESCRIPTION
Because basho/riak#355 hasn't landed yet I've added this. 

It allows one to set default HTTP headers which are used on each request, e.g. Authorization headers. This is useful when using Riak together with a [load balancer or proxy](http://docs.basho.com/riak/latest/ops/advanced/configs/load-balancing-proxy/) with basic auth.

Usage:

``` python
import riak
headers = {'Authorization': 'Basic {}'.format('riak:example'.encode('base64')).strip()}
http = riak.RiakClient(http_port=8080, protocol='http', transport_options={'default_headers': headers})
https = riak.RiakClient(http_port=8088, protocol='https', transport_options={'default_headers': headers})
```
