### PR TITLE
Changed RiakError to subclass StandardError to address multiget issue in ticket #296

### DIFF
--- a/riak/__init__.py
+++ b/riak/__init__.py
@@ -35,7 +35,7 @@ __all__ = ['RiakBucket', 'RiakNode', 'RiakObject', 'RiakClient',
            'ConflictError', 'ONE', 'ALL', 'QUORUM', 'key_filter']
 
 
-class RiakError(Exception):
+class RiakError(StandardError):
     """
     Base class for exceptions generated in the Riak API.
     """


### PR DESCRIPTION
Timeouts in multiget hang due to their exceptions not being caught by the parent thread. As noted by @seancribbs in ticket #296, the problem is that multiget tries to catch exceptions that are subclass of StandardError and not the more generic Exception. By changing the the subclass of RiakError, it appears to solve the problem.
