### PR TITLE
multiget: Catch RiakError and other errors not covered by StandardError

### DIFF
--- a/riak/client/multiget.py
+++ b/riak/client/multiget.py
@@ -131,7 +131,7 @@ class MultiGetPool(object):
                 task.outq.put(obj)
             except KeyboardInterrupt:
                 raise
-            except StandardError as err:
+            except Exception as err:
                 task.outq.put((task.bucket, task.key, err), )
             finally:
                 self._inq.task_done()


### PR DESCRIPTION
This should address #296, where `RiakError` exceptions were not propagated during multiget.
