### PR TITLE
Fix type of resource paths not being bytes.

### DIFF
--- a/riak/transports/http/transport.py
+++ b/riak/transports/http/transport.py
@@ -104,7 +104,15 @@ class RiakHttpTransport(RiakHttpConnection, RiakHttpResources, RiakHttpCodec,
         status, _, body = self._request('GET', '/',
                                         {'Accept': 'application/json'})
         if status == 200:
-            return json.loads(body)
+            tmp, resources = json.loads(body), {}
+            for k in tmp:
+                # The keys and values returned by json.loads() are unicode,
+                # which will cause problems when passed into httplib later
+                # (expecting bytes both in Python 2.x and 3.x).
+                # We just encode the resource paths into bytes, with an
+                # encoding consistent with what the resources module expects.
+                resources[k] = tmp[k].encode('utf-8')
+            return resources
         else:
             return {}
 


### PR DESCRIPTION
Formerly the resource paths would just be what `json.loads` returned, which would be Unicode strings. This would cause problems when the `resources` module generates the URIs, silently being converted to `unicode`, ultimately leading to `httplib` complaining `UnicodeDecodeError` in some cases, e.g. setting non-ASCII values for 2i.

This commit just encodes the returned paths with UTF-8, which should fix the issue.

Thanks in advance!
