### PR TITLE
Fix JSON Error during HTTP stream_keys() Operation

### DIFF
--- a/riak/tests/test_kv.py
+++ b/riak/tests/test_kv.py
@@ -4,7 +4,7 @@ import cPickle
 import copy
 import platform
 from time import sleep
-from riak import ConflictError, RiakBucket
+from riak import ConflictError, RiakBucket, RiakError
 from riak.resolver import default_resolver, last_written_resolver
 try:
     import simplejson as json
@@ -140,6 +140,16 @@ class BasicKVTests(object):
                 self.assertIsInstance(key, basestring)
             streamed_keys += keylist
         self.assertEqual(sorted(regular_keys), sorted(streamed_keys))
+
+    def test_stream_keys_timeout(self):
+        bucket = self.client.bucket('random_key_bucket')
+        streamed_keys = []
+        with self.assertRaises(RiakError):
+            for keylist in self.client.stream_keys(bucket, timeout=1):
+                self.assertNotEqual([], keylist)
+                for key in keylist:
+                    self.assertIsInstance(key, basestring)
+                streamed_keys += keylist
 
     def test_stream_keys_abort(self):
         bucket = self.client.bucket('random_key_bucket')

--- a/riak/transports/http/stream.py
+++ b/riak/transports/http/stream.py
@@ -65,7 +65,11 @@ class RiakHttpJsonStream(RiakHttpStream):
             idx = string.index(self.buffer, '}') + 1
             chunk = self.buffer[:idx]
             self.buffer = self.buffer[idx:]
-            field = json.loads(chunk)[self._json_field]
+            jsdict = json.loads(chunk)
+            if 'error' in jsdict:
+                self.close()
+                raise RiakError(jsdict['error'])
+            field = jsdict[self._json_field]
             return field
         else:
             raise StopIteration


### PR DESCRIPTION
If there is a JSON error, repackage the message into a `RiakError` and throw that instead.  Addresses https://github.com/basho/riak-python-client/issues/289
