### PR TITLE
Set multiValued false in schema test

### DIFF
--- a/riak/tests/test_yokozuna.py
+++ b/riak/tests/test_yokozuna.py
@@ -63,16 +63,23 @@ class YZSearchTests(object):
         <schema name="test" version="1.5">
         <fields>
            <field name="_yz_id" type="_yz_str" indexed="true" stored="true"
-            required="true" />
-           <field name="_yz_ed" type="_yz_str" indexed="true" stored="true"/>
-           <field name="_yz_pn" type="_yz_str" indexed="true" stored="true"/>
-           <field name="_yz_fpn" type="_yz_str" indexed="true" stored="true"/>
-           <field name="_yz_vtag" type="_yz_str" indexed="true" stored="true"/>
-           <field name="_yz_node" type="_yz_str" indexed="true" stored="true"/>
-           <field name="_yz_rk" type="_yz_str" indexed="true" stored="true"/>
-           <field name="_yz_rb" type="_yz_str" indexed="true" stored="true"/>
-           <field name="_yz_rt" type="_yz_str" indexed="true" stored="true"/>
-           <field name="_yz_err" type="_yz_str" indexed="true"/>
+            multiValued="false" required="true" />
+           <field name="_yz_ed" type="_yz_str" indexed="true" stored="true"
+            multiValued="false" />
+           <field name="_yz_pn" type="_yz_str" indexed="true" stored="true"
+            multiValued="false" />
+           <field name="_yz_fpn" type="_yz_str" indexed="true" stored="true"
+            multiValued="false" />
+           <field name="_yz_vtag" type="_yz_str" indexed="true" stored="true"
+            multiValued="false" />
+           <field name="_yz_rk" type="_yz_str" indexed="true" stored="true"
+            multiValued="false" />
+           <field name="_yz_rb" type="_yz_str" indexed="true" stored="true"
+            multiValued="false" />
+           <field name="_yz_rt" type="_yz_str" indexed="true" stored="true"
+            multiValued="false" />
+           <field name="_yz_err" type="_yz_str" indexed="true"
+            multiValued="false" />
         </fields>
         <uniqueKey>_yz_id</uniqueKey>
         <types>


### PR DESCRIPTION
With basho/yokozuna#393, multiValued must now be set to false in solr schemas. This changes those values in the test.
