### PR TITLE
Attempt to fix exception thrown in test_index_timeout() 

### DIFF
--- a/riak/transports/security.py
+++ b/riak/transports/security.py
@@ -84,6 +84,7 @@ class RiakWrappedSocket(object):
             else:
                 raise err
 
+
 # Blatantly Stolen from
 # https://github.com/shazow/urllib3/blob/master/urllib3/contrib/pyopenssl.py
 # which is basically a port of the `socket._fileobject` class


### PR DESCRIPTION
The test failure seems to only be security tests.  It looks like an empty exception is being thrown, so ignore that if that's the case, otherwise propagate the exception.
