### PR TITLE
Cache Certificates in SecurityCreds

### DIFF
--- a/riak/tests/test_security.py
+++ b/riak/tests/test_security.py
@@ -31,7 +31,8 @@ from riak.security import SecurityCreds
 class SecurityTests(object):
     @unittest.skipIf(RUN_SECURITY, 'RUN_SECURITY is set')
     def test_security_disabled(self):
-        creds = SecurityCreds(SECURITY_USER, SECURITY_PASSWD,
+        creds = SecurityCreds(username=SECURITY_USER,
+                              password=SECURITY_PASSWD,
                               cacert_file=SECURITY_CACERT)
         client = self.create_client(credentials=creds)
         myBucket = client.bucket('test')
@@ -50,7 +51,7 @@ class SecurityTests(object):
 
     @unittest.skipUnless(RUN_SECURITY, 'RUN_SECURITY is not set')
     def test_security_bad_user(self):
-        creds = SecurityCreds('foo', SECURITY_PASSWD,
+        creds = SecurityCreds(username='foo', password=SECURITY_PASSWD,
                               cacert_file=SECURITY_CACERT)
         client = self.create_client(credentials=creds)
         with self.assertRaises(Exception):
@@ -58,7 +59,7 @@ class SecurityTests(object):
 
     @unittest.skipUnless(RUN_SECURITY, 'RUN_SECURITY is not set')
     def test_security_bad_password(self):
-        creds = SecurityCreds(SECURITY_USER, 'foo',
+        creds = SecurityCreds(username=SECURITY_USER, password='foo',
                               cacert_file=SECURITY_CACERT)
         client = self.create_client(credentials=creds)
         with self.assertRaises(Exception):
@@ -66,7 +67,7 @@ class SecurityTests(object):
 
     @unittest.skipUnless(RUN_SECURITY, 'RUN_SECURITY is not set')
     def test_security_missing_cert(self):
-        creds = SecurityCreds(SECURITY_USER, SECURITY_PASSWD,
+        creds = SecurityCreds(username=SECURITY_USER, password=SECURITY_PASSWD,
                               cacert_file='/tmp/foo')
         client = self.create_client(credentials=creds)
         with self.assertRaises(Exception):
@@ -74,10 +75,10 @@ class SecurityTests(object):
 
     @unittest.skipUnless(RUN_SECURITY, 'RUN_SECURITY is not set')
     def test_security_cert_authentication(self):
-        creds = SecurityCreds(SECURITY_CERT_USER,
-                              SECURITY_CERT_PASSWD,
+        creds = SecurityCreds(username=SECURITY_CERT_USER,
+                              password=SECURITY_CERT_PASSWD,
                               cert_file=SECURITY_CERT,
-                              key_file=SECURITY_KEY)
+                              pkey_file=SECURITY_KEY)
         client = self.create_client(credentials=creds)
         myBucket = client.bucket('test')
         val1 = "foobar2"
@@ -94,7 +95,7 @@ class SecurityTests(object):
 
     @unittest.skipUnless(RUN_SECURITY, 'RUN_SECURITY is not set')
     def test_security_revoked_cert(self):
-        creds = SecurityCreds(SECURITY_USER, SECURITY_PASSWD,
+        creds = SecurityCreds(username=SECURITY_USER, password=SECURITY_PASSWD,
                               cacert_file=SECURITY_CACERT,
                               crl_file=SECURITY_REVOKED)
         client = self.create_client(credentials=creds)
@@ -103,7 +104,7 @@ class SecurityTests(object):
 
     @unittest.skipUnless(RUN_SECURITY, 'RUN_SECURITY is not set')
     def test_security_bad_ca_cert(self):
-        creds = SecurityCreds(SECURITY_USER, SECURITY_PASSWD,
+        creds = SecurityCreds(username=SECURITY_USER, password=SECURITY_PASSWD,
                               cacert_file=SECURITY_BAD_CERT)
         client = self.create_client(credentials=creds)
         with self.assertRaises(Exception):
@@ -111,7 +112,7 @@ class SecurityTests(object):
 
     @unittest.skipUnless(RUN_SECURITY, 'RUN_SECURITY is not set')
     def test_security_ciphers(self):
-        creds = SecurityCreds(SECURITY_USER, SECURITY_PASSWD,
+        creds = SecurityCreds(username=SECURITY_USER, password=SECURITY_PASSWD,
                               ciphers='DHE-RSA-AES256-SHA')
         client = self.create_client(credentials=creds)
         myBucket = client.bucket('test')
@@ -122,7 +123,7 @@ class SecurityTests(object):
 
     @unittest.skipUnless(RUN_SECURITY, 'RUN_SECURITY is not set')
     def test_security_bad_ciphers(self):
-        creds = SecurityCreds(SECURITY_USER, SECURITY_PASSWD,
+        creds = SecurityCreds(username=SECURITY_USER, password=SECURITY_PASSWD,
                               ciphers='ECDHE-RSA-AES256-GCM-SHA384')
         client = self.create_client(credentials=creds)
         with self.assertRaises(Exception):

--- a/riak/transports/http/__init__.py
+++ b/riak/transports/http/__init__.py
@@ -21,7 +21,7 @@ import httplib
 import socket
 import select
 
-from riak.security import SecurityError, check_revoked_cert
+from riak.security import SecurityError
 from riak.transports.security import RiakWrappedSocket, configure_context
 from riak.transports.pool import Pool
 from riak.transports.http.transport import RiakHttpTransport
@@ -47,7 +47,7 @@ class RiakHTTPSConnection(httplib.HTTPSConnection):
                  host,
                  port,
                  credentials,
-                 key_file=None,
+                 pkey_file=None,
                  cert_file=None,
                  ciphers=None,
                  timeout=None):
@@ -61,10 +61,10 @@ class RiakHTTPSConnection(httplib.HTTPSConnection):
         :type port: int
         :param credentials: Security Credential settings
         :type  credentials: SecurityCreds
-        :param key_file: PEM formatted file that contains your private key
-        :type key_file: str
+        :param pkey_file: PEM formatted file that contains your private key
+        :type pkey_file: str
         :param cert_file: PEM formatted certificate chain file
-        :type key_file: str
+        :type cert_file: str
         :param ciphers: List of supported SSL ciphers
         :type ciphers: str
         :param timeout: Number of seconds before timing out
@@ -73,9 +73,9 @@ class RiakHTTPSConnection(httplib.HTTPSConnection):
         httplib.HTTPSConnection.__init__(self,
                                          host,
                                          port,
-                                         key_file=key_file,
+                                         key_file=pkey_file,
                                          cert_file=cert_file)
-        self.key_file = key_file
+        self.pkey_file = pkey_file
         self.cert_file = cert_file
         self.credentials = credentials
         self.timeout = timeout
@@ -102,8 +102,8 @@ class RiakHTTPSConnection(httplib.HTTPSConnection):
             break
 
         self.sock = RiakWrappedSocket(cxn, sock)
-        if self.credentials.crl_file:
-            check_revoked_cert(self.sock, self.credentials.crl_file)
+        if self.credentials.has_credential('crl'):
+            self.credentials.check_revoked_cert(self.sock)
 
 
 class RiakHttpPool(Pool):

--- a/riak/transports/pbc/connection.py
+++ b/riak/transports/pbc/connection.py
@@ -19,7 +19,7 @@ under the License.
 import socket
 import struct
 import riak_pb
-from riak.security import SecurityError, check_revoked_cert
+from riak.security import SecurityError
 from riak.transports.security import configure_context
 from riak import RiakError
 from riak_pb.messages import (
@@ -117,7 +117,6 @@ class RiakPbcConnection(object):
         if self._client._credentials:
             ssl_ctx = \
                 Context(self._client._credentials.ssl_version)
-            crl_file = self._client._credentials.crl_file
             try:
                 configure_context(ssl_ctx, self._client._credentials)
                 # attempt to upgrade the socket to SSL
@@ -127,8 +126,8 @@ class RiakPbcConnection(object):
                 # ssl handshake successful
                 self._socket = ssl_socket
 
-                if crl_file is not None:
-                    check_revoked_cert(ssl_socket, crl_file)
+                if self._client._credentials.has_credential('crl'):
+                    self._client._credentials.check_revoked_cert(ssl_socket)
 
                 return True
             except Exception as e:

--- a/riak/transports/security.py
+++ b/riak/transports/security.py
@@ -29,20 +29,18 @@ def configure_context(ssl_ctx, credentials):
     Set various options on the SSL context.
 
     :param ssl_ctx: OpenSSL context
-    :type ssl_ctx: OpenSSL.SSL.Context
+    :type ssl_ctx: :py:class `~OpenSSL.SSL.Context`
     :param credentials: Riak Security Credentials
-    :type credentials:
+    :type credentials: :py:class `~riak.security.SecurityCreds`
     """
-    key_file = credentials.key_file
-    cert_file = credentials.cert_file
-    cacert_file = credentials.cacert_file
+
+    if credentials.has_credential('pkey'):
+        ssl_ctx.use_privatekey(credentials.pkey)
+    if credentials.has_credential('cert'):
+        ssl_ctx.use_certificate(credentials.cert)
+    if credentials.has_credential('cacert'):
+        ssl_ctx.add_extra_chain_cert(credentials.cacert)
     ciphers = credentials.ciphers
-    if key_file is not None:
-        ssl_ctx.use_privatekey_file(key_file)
-    if cert_file is not None:
-        ssl_ctx.use_certificate_chain_file(cert_file)
-    if cacert_file is not None:
-        ssl_ctx.load_verify_locations(cacert_file)
     if ciphers is not None:
         ssl_ctx.set_cipher_list(ciphers)
 


### PR DESCRIPTION
Instead of loading the files when the SSL connection is initiated, cache the credentials in the `SecurityCreds` object to speed up integration tests.  Also convert the class to work more like a dictionary. 
