### PR TITLE
Add basic_quorum and notfound_ok request options on get.

### DIFF
--- a/riak/bucket.py
+++ b/riak/bucket.py
@@ -173,7 +173,8 @@ class RiakBucket(object):
             obj.encoded_data = encoded_data
         return obj
 
-    def get(self, key, r=None, pr=None, timeout=None, include_context=None):
+    def get(self, key, r=None, pr=None, timeout=None, include_context=None,
+            basic_quorum=None, notfound_ok=None):
         """
         Retrieve an object or datatype from Riak.
 
@@ -188,18 +189,28 @@ class RiakBucket(object):
         :param include_context: if the bucket contains datatypes, include
            the opaque context in the result
         :type include_context: bool
+        :param basic_quorum: whether to use the "basic quorum" policy
+           for not-founds
+        :type basic_quorum: bool
+        :param notfound_ok: whether to treat not-found responses as successful
+        :type notfound_ok: bool
         :rtype: :class:`RiakObject <riak.riak_object.RiakObject>` or
            :class:`~riak.datatypes.Datatype`
         """
         if self.bucket_type.datatype:
             return self._client.fetch_datatype(self, key, r=r, pr=pr,
                                                timeout=timeout,
-                                               include_context=include_context)
+                                               include_context=include_context,
+                                               basic_quorum=basic_quorum,
+                                               notfound_ok=notfound_ok)
         else:
             obj = RiakObject(self._client, self, key)
-            return obj.reload(r=r, pr=pr, timeout=timeout)
+            return obj.reload(r=r, pr=pr, timeout=timeout,
+                              basic_quorum=basic_quorum,
+                              notfound_ok=notfound_ok)
 
-    def multiget(self, keys, r=None, pr=None):
+    def multiget(self, keys, r=None, pr=None, timeout=None,
+                 basic_quorum=None, notfound_ok=None):
         """
         Retrieves a list of keys belonging to this bucket in parallel.
 
@@ -209,11 +220,19 @@ class RiakBucket(object):
         :type r: integer
         :param pr: PR-Value for the requests (defaults to bucket's PR)
         :type pr: integer
-        :rtype: list of :class:`RiakObject <riak.riak_object.RiakObject>` or
-                tuples of bucket_type, bucket, key, and the exception raised
+        :param timeout: a timeout value in milliseconds
+        :type timeout: int
+        :param basic_quorum: whether to use the "basic quorum" policy
+           for not-founds
+        :type basic_quorum: bool
+        :param notfound_ok: whether to treat not-found responses as successful
+        :type notfound_ok: bool
+        :rtype: list of :class:`RiakObject <riak.riak_object.RiakObject>`
         """
         bkeys = [(self.bucket_type.name, self.name, key) for key in keys]
-        return self._client.multiget(bkeys, r=r, pr=pr)
+        return self._client.multiget(bkeys, r=r, pr=pr, timeout=timeout,
+                                     basic_quorum=basic_quorum,
+                                     notfound_ok=notfound_ok)
 
     def _get_resolver(self):
         if callable(self._resolver):

--- a/riak/client/operations.py
+++ b/riak/client/operations.py
@@ -363,7 +363,8 @@ class RiakClientOperations(RiakClientTransport):
                              timeout=timeout)
 
     @retryable
-    def get(self, transport, robj, r=None, pr=None, timeout=None):
+    def get(self, transport, robj, r=None, pr=None, timeout=None,
+            basic_quorum=None, notfound_ok=None):
         """
         get(robj, r=None, pr=None, timeout=None)
 
@@ -380,13 +381,20 @@ class RiakClientOperations(RiakClientTransport):
         :type pr: integer, string, None
         :param timeout: a timeout value in milliseconds
         :type timeout: int
+        :param basic_quorum: whether to use the "basic quorum" policy
+           for not-founds
+        :type basic_quorum: bool
+        :param notfound_ok: whether to treat not-found responses as successful
+        :type notfound_ok: bool
         """
         _validate_timeout(timeout)
         if not isinstance(robj.key, basestring):
             raise TypeError(
                 'key must be a string, instead got {0}'.format(repr(robj.key)))
 
-        return transport.get(robj, r=r, pr=pr, timeout=timeout)
+        return transport.get(robj, r=r, pr=pr, timeout=timeout,
+                             basic_quorum=basic_quorum,
+                             notfound_ok=notfound_ok)
 
     @retryable
     def delete(self, transport, robj, rw=None, r=None, w=None, dw=None,

--- a/riak/riak_object.py
+++ b/riak/riak_object.py
@@ -274,7 +274,8 @@ class RiakObject(object):
 
         return self
 
-    def reload(self, r=None, pr=None, timeout=None):
+    def reload(self, r=None, pr=None, timeout=None, basic_quorum=None,
+               notfound_ok=None):
         """
         Reload the object from Riak. When this operation completes, the
         object could contain new metadata and a new value, if the object
@@ -293,6 +294,11 @@ class RiakObject(object):
         :type pr: integer
         :param timeout: a timeout value in milliseconds
         :type timeout: int
+        :param basic_quorum: whether to use the "basic quorum" policy
+           for not-founds
+        :type basic_quorum: bool
+        :param notfound_ok: whether to treat not-found responses as successful
+        :type notfound_ok: bool
         :rtype: :class:`RiakObject`
         """
 

--- a/riak/tests/test_kv.py
+++ b/riak/tests/test_kv.py
@@ -497,6 +497,20 @@ class BasicKVTests(object):
         self.assertTrue(robj.exists)
         self.assertEqual(len(robj.siblings), 1)
 
+    def test_get_params(self):
+        bucket = self.client.bucket(self.bucket_name)
+        bucket.new(self.key_name, data={"foo": "one",
+                                        "bar": "baz"}).store()
+
+        bucket.get(self.key_name, basic_quorum=False)
+        bucket.get(self.key_name, basic_quorum=True)
+        bucket.get(self.key_name, notfound_ok=True)
+        bucket.get(self.key_name, notfound_ok=False)
+
+        missing = bucket.get('missing-key', notfound_ok=True,
+                             basic_quorum=True)
+        self.assertFalse(missing.exists)
+
     def generate_siblings(self, original, count=5, delay=None):
         vals = []
         for i in range(count):

--- a/riak/transports/http/transport.py
+++ b/riak/transports/http/transport.py
@@ -117,13 +117,16 @@ class RiakHttpTransport(RiakHttpConnection, RiakHttpResources, RiakHttpCodec,
         else:
             return {}
 
-    def get(self, robj, r=None, pr=None, timeout=None):
+    def get(self, robj, r=None, pr=None, timeout=None, basic_quorum=None,
+            notfound_ok=None):
         """
         Get a bucket/key from the server
         """
         # We could detect quorum_controls here but HTTP ignores
         # unknown flags/params.
-        params = {'r': r, 'pr': pr, 'timeout': timeout}
+        params = {'r': r, 'pr': pr, 'timeout': timeout,
+                  'basic_quorum': basic_quorum,
+                  'notfound_ok': notfound_ok}
 
         bucket_type = self._get_bucket_type(robj.bucket.bucket_type)
 

--- a/riak/transports/transport.py
+++ b/riak/transports/transport.py
@@ -65,7 +65,8 @@ class RiakTransport(FeatureDetection):
         """
         raise NotImplementedError
 
-    def get(self, robj, r=None, pr=None, timeout=None):
+    def get(self, robj, r=None, pr=None, timeout=None, basic_quorum=None,
+            notfound_ok=None):
         """
         Fetches an object.
         """


### PR DESCRIPTION
I originally set out to investigate the deletedvclock issue in #332, but discovered that these quorum parameters were missing.
