### PR TITLE
Consider managing context more aggressively

### DIFF
--- a/riak/datatypes/datatype.py
+++ b/riak/datatypes/datatype.py
@@ -113,7 +113,7 @@ class Datatype(object):
                    be available before performing the put
         :type pw: integer
         :param return_body: if the newly stored object should be
-                            retrieved
+                            retrieved, defaults to True
         :type return_body: bool
         :param include_context: whether to return the new opaque
           context when `return_body` is `True`
@@ -125,7 +125,9 @@ class Datatype(object):
         if not self.modified:
             raise ValueError("No operation to perform")
 
+        params.setdefault('return_body', True)
         self.bucket._client.update_datatype(self, **params)
+        self.clear()
 
         return self
 

--- a/riak/tests/test_datatypes.py
+++ b/riak/tests/test_datatypes.py
@@ -405,3 +405,47 @@ class DatatypeIntegrationTests(object):
 
         map2 = bucket.get(self.key_name)
         self.assertItemsEqual(["Z"], map2.maps['map'].sets['set'])
+
+    @unittest.skipIf(SKIP_DATATYPES, 'SKIP_DATATYPES is set')
+    def test_dt_set_return_body_true_default(self):
+        btype = self.client.bucket_type('pytest-sets')
+        bucket = btype.bucket(self.bucket_name)
+        myset = bucket.new(self.key_name)
+        myset.add('X')
+        myset.store(return_body=False)
+        with self.assertRaises(datatypes.ContextRequired):
+            myset.discard('X')
+
+        myset.add('Y')
+        myset.store()
+        self.assertItemsEqual(myset.value, ['X', 'Y'])
+
+        myset.discard('X')
+        myset.store()
+        self.assertItemsEqual(myset.value, ['Y'])
+
+    @unittest.skipIf(SKIP_DATATYPES, 'SKIP_DATATYPES is set')
+    def test_dt_map_return_body_true_default(self):
+        btype = self.client.bucket_type('pytest-maps')
+        bucket = btype.bucket(self.bucket_name)
+        mymap = bucket.new(self.key_name)
+        mymap.sets['a'].add('X')
+        mymap.store(return_body=False)
+        with self.assertRaises(datatypes.ContextRequired):
+            mymap.sets['a'].discard('X')
+        with self.assertRaises(datatypes.ContextRequired):
+            del mymap.sets['a']
+
+        mymap.sets['a'].add('Y')
+        mymap.store()
+        print mymap
+        self.assertItemsEqual(mymap.sets['a'].value, ['X', 'Y'])
+
+        mymap.sets['a'].discard('X')
+        mymap.store()
+        self.assertItemsEqual(mymap.sets['a'].value, ['Y'])
+
+        del mymap.sets['a']
+        mymap.store()
+
+        self.assertEqual(mymap.value, {})

--- a/riak/transports/http/transport.py
+++ b/riak/transports/http/transport.py
@@ -732,6 +732,9 @@ class RiakHttpTransport(RiakHttpConnection, RiakHttpResources, RiakHttpCodec,
             raise TypeError("Cannot send operation on datatype {!r}".
                             format(type_name))
 
+        if 'return_body' in options:
+            options['returnbody'] = options['return_body']
+
         url = self.datatypes_path(datatype.bucket.bucket_type.name,
                                   datatype.bucket.name,
                                   datatype.key, **options)
@@ -748,11 +751,11 @@ class RiakHttpTransport(RiakHttpConnection, RiakHttpResources, RiakHttpCodec,
         if status == 201:
             datatype.key = headers['location'].strip().split('/')[-1]
 
-        if options.get('return_body') and status is not 204:
+        if status != 204:
             response = json.loads(body)
+            datatype._context = response.get('context')
             datatype._set_value(self._decode_datatype(type_name,
                                                       response['value']))
-            datatype._context = response.get('context')
 
         return True
 


### PR DESCRIPTION
``` python
>>> myset.store()
<riak.datatypes.set.Set object at 0x107a13b10>
>>> myset.discard('fritz')
>>> myset.store()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "riak/datatypes/datatype.py", line 136, in update
    self.bucket._client.update_datatype(self, **params)
  File "riak/client/operations.py", line 748, in update_datatype
    include_context=include_context)
  File "riak/transports/pbc/transport.py", line 697, in update_datatype
    MSG_CODE_DT_UPDATE_RESP)
  File "riak/transports/pbc/connection.py", line 43, in _request
    return self._recv_msg(expect)
  File "riak/transports/pbc/connection.py", line 55, in _recv_msg
    raise RiakError(err.errmsg)
riak.RiakError: '{precondition,{not_present,<<"fritz">>}}'
```

However, if I add a `myset.reload()` invocation before `store()`, things work as expected.

So, I'd wager that the vector clock isn't being pulled into the object as part of the `store` operation. I think this behavior will be unexpected, although I'll admit that forcing developers to do `reload` before storing objects may make sense in a highly concurrent environment.
