### PR TITLE
multiget does not always return RiakObjects, as stated in documentation

### DIFF
--- a/riak/bucket.py
+++ b/riak/bucket.py
@@ -259,7 +259,8 @@ class RiakBucket(object):
         :type r: integer
         :param pr: PR-Value for the requests (defaults to bucket's PR)
         :type pr: integer
-        :rtype: list of :class:`RiakObject <riak.riak_object.RiakObject>`
+        :rtype: list of :class:`RiakObject <riak.riak_object.RiakObject>` or
+                tuples of bucket_type, bucket, key, and the exception raised
         """
         bkeys = [(self.bucket_type.name, self.name, key) for key in keys]
         return self._client.multiget(bkeys, r=r, pr=pr)

--- a/riak/client/operations.py
+++ b/riak/client/operations.py
@@ -600,12 +600,12 @@ class RiakClientOperations(RiakClientTransport):
         """
         Fetches many keys in parallel via threads.
 
-        :param pairs: list of bucket/key tuple pairs
+        :param pairs: list of bucket_type/bucket/key tuple triples
         :type pairs: list
         :param params: additional request flags, e.g. r, pr
         :type params: dict
-        :rtype: list of :class:`RiakObject <riak.riak_object.RiakObject>`
-            instances
+        :rtype: list of :class:`RiakObjects <riak.riak_object.RiakObject>` or
+                tuples of bucket_type, bucket, key, and the exception raised
         """
         return multiget(self, pairs, **params)
 


### PR DESCRIPTION
In a live application that we have deployed with Riak, we have noticed the following error message in the logs periodically, coming after some code that is expecting a RiakObject:

```
AttributeError: 'tuple' object has no attribute 'bucket'
```

We are attempting to access `obj.bucket.name` from an `obj` returned from  `client.multiget`:

```
for obj in client.multiget(keys):
    if obj.bucket.name == test_bucket_name:
        ...
```

It is noted in the documentation that multiget should return a list of RiakObjects:
http://basho.github.io/riak-python-client/client.html#riak.client.RiakClient.multiget

However, it is clearly returning a `tuple` periodically according to the above examples.

I have been able to deterministically replicate this issue with a very short code sample, here:

```
from riak import RiakClient, RiakNode

client = RiakClient(nodes=[]) # Node list intentionally left empty
bkeys = [('testbucket', 'key%s' % i) for i in range(100)]

for obj in client.multiget(bkeys):
    print obj.bucket.name
```

Here is the result:

```
Traceback (most recent call last):
  File "test.py", line 7, in <module>
    print obj.bucket.name
AttributeError: 'tuple' object has no attribute 'bucket'
```

And here is what is contained in that tuple:

```
('testbucket', 'key73', ValueError('min() arg is an empty sequence',))
```

It seems that when encountering an exception, it returns a tuple which contains the exception in the third position.

The work-around for our code is obvious. We will simply check if the result is, in fact, a RiakObject before trying to access the bucket property (or maybe wrap in a try-except) and deal with whatever the error message is.

But, I am reporting this as a bug since the documentation suggests that multiget should only return RiakObjects and not tuples.

At the very least, the documentation should be updated.

I realize that there is not any straight-forward way to pass an exception regarding the failure of a single query in a parallel operation, but some documentation about this would be especially helpful for anyone else who is trying to use multiget properly.

Thanks!
