### PR TITLE
Bucket search does not allow bucket/index name to differ

### DIFF
--- a/riak/bucket.py
+++ b/riak/bucket.py
@@ -411,13 +411,21 @@ class RiakBucket(object):
             self.set_property('search', False)
         return True
 
-    def search(self, query, **params):
+    def search(self, query, index=None, **params):
         """
         Queries a search index over objects in this bucket/index. See
         :meth:`RiakClient.fulltext_search()
         <riak.client.RiakClient.fulltext_search>` for more details.
+
+        :param query: the search query
+        :type query: string
+        :param index: the index to search over
+        :type index: string or None
+        :param params: additional query flags
+        :type params: dict
         """
-        return self._client.fulltext_search(self.name, query, **params)
+        search_index = self.name if index is None else index
+        return self._client.fulltext_search(search_index, query, **params)
 
     def get_index(self, index, startkey, endkey=None, return_terms=None,
                   max_results=None, continuation=None, timeout=None,

--- a/riak/tests/test_mapreduce.py
+++ b/riak/tests/test_mapreduce.py
@@ -351,8 +351,8 @@ class JSMapReduceTests(object):
         """
         Try a successful map/reduce from search results.
         """
-        btype = self.client.bucket_type(self.mr_btype)
-        bucket = btype.bucket(self.mr_bucket)
+        btype = self.client.bucket_type(self.yz_mr['btype'])
+        bucket = btype.bucket(self.yz_mr['bucket'])
         bucket.new("Pebbles", {"name_s": "Fruity Pebbles",
                                "maker_s": "Post",
                                "sugar_i": 9,
@@ -380,7 +380,8 @@ class JSMapReduceTests(object):
                               "fruit_b": False}).store()
         # Wait for Solr to catch up
         wait_for_yz_index(bucket, "Crunch")
-        mr = RiakMapReduce(self.client).search(self.mr_bucket, 'fruit_b:false')
+        mr = RiakMapReduce(self.client).search(self.yz_mr['bucket'],
+                                               'fruit_b:false')
         mr.map("""function(v) {
             var solr_doc = JSON.parse(v.values[0].data);
             return [solr_doc["calories_i"]]; }""")


### PR DESCRIPTION
An enthusiastic ML member was trying to search via the bucket interface:

```
bucket = client.bucket_type('animals').bucket('cats')
bucket.enable_search()
bucket.set_property('search_index', 'famous') # NEW: Setting the search index to the bucket
key = bucket.new('feliz', data={"name":"Felix","species":"Felis catus"}, content_type='application/json')
key.store()
print bucket.search('name=Felix')

riak.RiakError: 'No index <<"cats">> found.'
```

The client interface allows for the name to be specified:

```
    def fulltext_search(self, transport, index, query, **params):
        """
        fulltext_search(index, query, **params)

        Performs a full-text search query.

        .. note:: This request is automatically retried :attr:`retries`
           times if it fails due to network error.

        :param index: the bucket/index to search over
        :type index: string
        :param query: the search query
        :type query: string
        :param params: additional query flags
        :type params: dict
```

We should tweak the bucket call to optionally specify the index name, since it's currently set to the bucket name:

```
    def search(self, query, **params):
        """
        Queries a search index over objects in this bucket/index. See
        :meth:`RiakClient.fulltext_search()
        <riak.client.RiakClient.fulltext_search>` for more details.
        """
        return self._client.fulltext_search(self.name, query, **params)
```
