### PR TITLE
Fixed a bug with the implementation of Mapping.__iter__

### DIFF
--- a/riak/datatypes/map.py
+++ b/riak/datatypes/map.py
@@ -33,7 +33,7 @@ class TypedMapView(Mapping):
         for key in self.map.value:
             name, datatype = key
             if datatype == self.datatype:
-                yield self.map[key]
+                yield name
 
     def __len__(self):
         """


### PR DESCRIPTION
Mapping.**iter** iterates over the keys not the values.  This bugs
caused Mapping.items() to malfunction.
