### PR TITLE
Add optional `bucket_type` parameter for Map/Reduce

### DIFF
--- a/riak/riak_object.py
+++ b/riak/riak_object.py
@@ -358,16 +358,25 @@ class RiakObject(object):
         self.siblings = []
         return self
 
-    def add(self, *args):
+    def add(self, arg1, arg2=None, arg3=None, bucket_type=None):
         """
         Start assembling a Map/Reduce operation.
         A shortcut for :meth:`~riak.mapreduce.RiakMapReduce.add`.
 
+        :param arg1: the object or bucket to add
+        :type arg1: RiakObject, string
+        :param arg2: a key or list of keys to add (if a bucket is
+          given in arg1)
+        :type arg2: string, list, None
+        :param arg3: key data for this input (must be convertible to JSON)
+        :type arg3: string, list, dict, None
+        :param bucket_type: Optional name of a bucket type
+        :type bucket_type: string, None
         :rtype: :class:`~riak.mapreduce.RiakMapReduce`
         """
         mr = RiakMapReduce(self.client)
-        mr.add(self.bucket.name, self.key)
-        return mr.add(*args)
+        mr.add(self.bucket.name, self.key, bucket_type=bucket_type)
+        return mr.add(arg1, arg2, arg3, bucket_type)
 
     def link(self, *args):
         """


### PR DESCRIPTION
It looks like support for bucket types were overlooked when the `riak-python-client` was updated to version 2.1.0 to support Riak 2.0.  This addresses issue https://github.com/basho/riak-python-client/issues/383.

Essentially the `add()` function now supports an optional `bucket_type` argument which will percolate down to the M/R JSON sent to Riak.  If it is not supplied or is `None` it is assumed that the `default` bucket type is being used. `index()` was also updated, but `search()` was not since it actually now uses Solr indexes instead of bucket types.
