### PR TITLE
Atomically create a new RiakBucket to avoid race condition in duplication

### DIFF
--- a/riak/client/__init__.py
+++ b/riak/client/__init__.py
@@ -267,12 +267,8 @@ class RiakClient(RiakMapReduceChain, RiakClientOperations):
             raise TypeError('bucket_type must be a string '
                             'or riak.bucket.BucketType')
 
-        if (bucket_type, name) in self._buckets:
-            return self._buckets[(bucket_type, name)]
-        else:
-            bucket = RiakBucket(self, name, bucket_type)
-            self._buckets[(bucket_type, name)] = bucket
-            return bucket
+        return self._buckets.setdefault((bucket_type, name),
+                                        RiakBucket(self, name, bucket_type))
 
     def bucket_type(self, name):
         """


### PR DESCRIPTION
Use the Python built-in [dict.setdefault()](https://docs.python.org/2/library/stdtypes.html#dict.setdefault) to check for the existence of the bucket in the client bucket list and add if if it does not exist.  This addresses issue #380 (CLIENTS-53) 
