### PR TITLE
CLIENTS-115: Use pyenv for multiple Python versions and tox to test them

### DIFF
--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -21,14 +21,23 @@ lint:
 	@openssl verify -CAfile ${CERTS_DIR}/ca.crt ${CERTS_DIR}/client.crt
 	@openssl verify -CAfile ${CERTS_DIR}/ca.crt ${CERTS_DIR}/server.crt
 
-test: test_normal test_security
+test: setup test_normal test_security
 
 test_normal:
 	@echo "Testing Riak Python Client (without security)"
 	@../setup.py disable_security --riak-admin=${RIAK_ADMIN}
-	@RUN_YZ=1 SKIP_DATATYPES=0 SKIP_INDEXES=0 ../setup.py test
+	@RUN_YZ=1 SKIP_DATATYPES=0 SKIP_INDEXES=0 ./tox_runner.sh ..
 
 test_security:
 	@echo "Testing Riak Python Client (with security)"
 	@../setup.py enable_security --riak-admin=${RIAK_ADMIN}
-	(cd ..; RUN_YZ=1 SKIP_INDEXES=0 RUN_SECURITY=1 SKIP_POOL=1 SKIP_RESOLVE=1 RIAK_TEST_HTTP_PORT=18098 ./setup.py test)
+	@RUN_YZ=1 SKIP_INDEXES=0 RUN_SECURITY=1 SKIP_POOL=1 SKIP_RESOLVE=1 RIAK_TEST_HTTP_PORT=18098 ./tox_runner.sh ..
+
+# These are required to actually build all the Python versions:
+# * pip install tox
+# * pyenv - https://github.com/yyuu/pyenv
+# And two pyenv plugins:
+# * pyenv virtualenv - https://github.com/yyuu/pyenv-virtualenv
+# * pyenv alias - https://github.com/s1341/pyenv-alias
+setup:
+	./tox_setup.sh

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -11,7 +11,6 @@ configure:
 	@../setup.py configure --riak-admin=${RIAK_ADMIN}
 
 compile:
-	-@yes y | pip uninstall riak-pb protobuf pyOpenSSL
 	@../setup.py develop
 
 lint:

--- a/buildbot/tox_runner.sh
+++ b/buildbot/tox_runner.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# pyenv root
+export PYENV_ROOT="$HOME/.pyenv"
+
+# Add pyenv root to PATH
+# and initialize pyenv
+PATH="$PYENV_ROOT/bin:$PATH"
+# initialize pyenv
+eval "$(pyenv init -)"
+# initialize pyenv virtualenv
+eval "$(pyenv virtualenv-init -)"
+
+# Change directory if an argument is passed in
+if [[ ! -z "$1" ]]; then
+    cd "$1"
+fi
+tox

--- a/buildbot/tox_setup.sh
+++ b/buildbot/tox_setup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# pyenv root
+export PYENV_ROOT="$HOME/.pyenv"
+
+# Install pyenv if it's missing
+if [[ ! -d $PYENV_ROOT ]]; then
+    git clone git://github.com/yyuu/pyenv.git ${PYENV_ROOT}
+    cd ${PYENV_ROOT}
+    # Get the latest tagged version
+    git checkout `git tag | tail -1`
+    git clone https://github.com/yyuu/pyenv-virtualenv.git ${PYENV_ROOT}/plugins/pyenv-virtualenv
+    cd plugins/pyenv-virtualenv
+    git checkout `git tag | tail -1`
+    git clone https://github.com/s1341/pyenv-alias.git ${PYENV_ROOT}/plugins/pyenv-alias
+
+    # Add pyenv root to PATH
+    # and initialize pyenv
+    PATH="$PYENV_ROOT/bin:$PATH"
+    # initialize pyenv
+    eval "$(pyenv init -)"
+    # initialize pyenv virtualenv
+    eval "$(pyenv virtualenv-init -)"
+
+    # Now load up (allthethings)
+    VERSION_ALIAS="riak_2.6.9" pyenv install 2.6.9
+    VERSION_ALIAS="riak_2.7.9" pyenv install 2.7.9
+    VERSION_ALIAS="riak_3.3.6" pyenv install 3.3.6
+    VERSION_ALIAS="riak_3.4.2" pyenv install 3.4.2
+
+    pyenv virtualenv riak_2.6.9 riak-py26
+    pyenv virtualenv riak_2.7.9 riak-py27
+    pyenv virtualenv riak_3.3.6 riak-py33
+    pyenv virtualenv riak_3.4.2 riak-py34
+    pyenv global riak-py26 riak-py27 riak-py33 riak-py34
+    pyenv versions
+fi
+
+# Now install tox
+if [ -z "`pip show tox`" ]; then
+    pip install tox
+    if [ -z "`pip show tox`" ]; then
+        echo "ERROR: Install of tox failed"
+        exit 1
+    fi
+    pyenv rehash
+fi

--- a/commands.py
+++ b/commands.py
@@ -421,6 +421,9 @@ class preconfigure(Command):
                       r'listener.protobuf.internal = ' + pb_host,
                       conf)
         conf += 'check_crl = off\n'
+        # Older versions of OpenSSL client library need to match on the server
+        conf += 'tls_protocols.tlsv1 = on\n'
+        conf += 'tls_protocols.tlsv1.1 = on\n'
         f = open(self.riak_conf, 'w', buffering=1)
         f.write(conf)
         f.close()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27, py33, py34
+
+[testenv]
+commands = {envpython} setup.py test
+deps = six


### PR DESCRIPTION
Traditionally we've targeted only Python 2.7.x as our supported build version.  In fact the native Ubuntu 12.04 LTS version 2.7.3 is the only one tested on buildbot.  Now we'll use `pyenv` to virtualize 4 versions and actually test all of them both with and without security:
- 2.6.9
- 2.7.9
- 3.3.6
- 3.4.2

The real downside is, naturally, that the tests will take 4x longer, but this way we can catch changes which break one platform or another.

NOTE: Because of the older version of OpenSSL installed on the builder we need to allow older TLS versions to be supported in Riak since the Python 3 versions use the builtin `ssl` library instead of `PyOpenSSL`.