### PR TITLE
Avoid dependency on pyOpenSSL when using Python 2.7.9 [JIRA: CLIENTS-408]

### DIFF
--- a/riak/tests/test_security.py
+++ b/riak/tests/test_security.py
@@ -17,8 +17,8 @@ specific language governing permissions and limitations
 under the License.
 """
 
-import platform
-if platform.python_version() < '2.7':
+import sys
+if sys.version_info < (2, 7):
     unittest = __import__('unittest2')
 else:
     import unittest
@@ -26,7 +26,6 @@ from riak.tests import RUN_SECURITY, SECURITY_USER, SECURITY_PASSWD, \
     SECURITY_CACERT, SECURITY_KEY, SECURITY_CERT, SECURITY_REVOKED, \
     SECURITY_CERT_USER, SECURITY_CERT_PASSWD, SECURITY_BAD_CERT
 from riak.security import SecurityCreds
-from six import PY3
 
 
 class SecurityTests(object):
@@ -110,9 +109,9 @@ class SecurityTests(object):
         creds = SecurityCreds(username=SECURITY_USER, password=SECURITY_PASSWD,
                               cacert_file=SECURITY_CACERT,
                               crl_file=SECURITY_REVOKED)
-        # Curenly Python 3.x native CRL doesn't seem to work
-        # as advertised
-        if PY3:
+        # Currently Python >= 2.7.9 and Python 3.x native CRL doesn't seem to
+        # work as advertised
+        if sys.version_info >= (2, 7, 9):
             return
         client = self.create_client(credentials=creds)
         with self.assertRaises(Exception):

--- a/riak/transports/pbc/connection.py
+++ b/riak/transports/pbc/connection.py
@@ -19,7 +19,7 @@ under the License.
 import socket
 import struct
 import riak_pb
-from riak.security import SecurityError
+from riak.security import SecurityError, USE_STDLIB_SSL
 from riak import RiakError
 from riak_pb.messages import (
     MESSAGE_CLASSES,
@@ -30,7 +30,7 @@ from riak_pb.messages import (
 )
 from riak.util import bytes_to_str, str_to_bytes
 from six import PY2
-if PY2:
+if not USE_STDLIB_SSL:
     from OpenSSL.SSL import Connection
     from riak.transports.security import configure_pyopenssl_context
 else:
@@ -113,7 +113,7 @@ class RiakPbcConnection(object):
         else:
             return False
 
-    if PY2:
+    if not USE_STDLIB_SSL:
         def _ssl_handshake(self):
             """
             Perform an SSL handshake w/ the server.

--- a/riak/transports/security.py
+++ b/riak/transports/security.py
@@ -17,16 +17,15 @@ under the License.
 """
 
 import socket
-from six import PY2
-if PY2:
+from riak.security import SecurityError, USE_STDLIB_SSL
+if USE_STDLIB_SSL:
+    import ssl
+else:
     import OpenSSL.SSL
     try:
         from cStringIO import StringIO
     except ImportError:
         from StringIO import StringIO
-else:
-    import ssl
-from riak.security import SecurityError
 
 
 def verify_cb(conn, cert, errnum, depth, ok):
@@ -39,42 +38,10 @@ def verify_cb(conn, cert, errnum, depth, ok):
     return ok
 
 
-if PY2:
-    def configure_pyopenssl_context(credentials):
-        """
-        Set various options on the SSL context for Python 2.x.
-
-        :param credentials: Riak Security Credentials
-        :type credentials: :class:`~riak.security.SecurityCreds`
-        :rtype ssl_ctx: :class:`~OpenSSL.SSL.Context`
-        """
-
-        ssl_ctx = OpenSSL.SSL.Context(credentials.ssl_version)
-        if credentials._has_credential('pkey'):
-            ssl_ctx.use_privatekey(credentials.pkey)
-        if credentials._has_credential('cert'):
-            ssl_ctx.use_certificate(credentials.cert)
-        if credentials._has_credential('cacert'):
-            store = ssl_ctx.get_cert_store()
-            cacerts = credentials.cacert
-            if not isinstance(cacerts, list):
-                cacerts = [cacerts]
-            for cacert in cacerts:
-                store.add_cert(cacert)
-        else:
-            raise SecurityError("cacert_file is required in SecurityCreds")
-        ciphers = credentials.ciphers
-        if ciphers is not None:
-            ssl_ctx.set_cipher_list(ciphers)
-        # Demand a certificate
-        ssl_ctx.set_verify(OpenSSL.SSL.VERIFY_PEER |
-                           OpenSSL.SSL.VERIFY_FAIL_IF_NO_PEER_CERT,
-                           verify_cb)
-        return ssl_ctx
-else:
+if USE_STDLIB_SSL:
     def configure_ssl_context(credentials):
         """
-        Set various options on the SSL context for Python 3.x.
+        Set various options on the SSL context for Python >= 2.7.9 and 3.x.
 
         N.B. versions earlier than 3.4 may not support all security
         measures, e.g., hostname check.
@@ -121,49 +88,80 @@ else:
 
         return ssl_ctx
 
-
-# Inspired by
-# https://github.com/shazow/urllib3/blob/master/urllib3/contrib/pyopenssl.py
-class RiakWrappedSocket(socket.socket):
-    def __init__(self, connection, socket):
+else:
+    def configure_pyopenssl_context(credentials):
         """
-        API-compatibility wrapper for Python OpenSSL's Connection-class.
+        Set various options on the SSL context for Python <= 2.7.8.
 
-        :param connection: OpenSSL connection
-        :type connection: OpenSSL.SSL.Connection
-        :param socket: Underlying already connected socket
-        :type socket: socket
+        :param credentials: Riak Security Credentials
+        :type credentials: :class:`~riak.security.SecurityCreds`
+        :rtype ssl_ctx: :class:`~OpenSSL.SSL.Context`
         """
-        self.connection = connection
-        self.socket = socket
 
-    def fileno(self):
-        return self.socket.fileno()
+        ssl_ctx = OpenSSL.SSL.Context(credentials.ssl_version)
+        if credentials._has_credential('pkey'):
+            ssl_ctx.use_privatekey(credentials.pkey)
+        if credentials._has_credential('cert'):
+            ssl_ctx.use_certificate(credentials.cert)
+        if credentials._has_credential('cacert'):
+            store = ssl_ctx.get_cert_store()
+            cacerts = credentials.cacert
+            if not isinstance(cacerts, list):
+                cacerts = [cacerts]
+            for cacert in cacerts:
+                store.add_cert(cacert)
+        else:
+            raise SecurityError("cacert_file is required in SecurityCreds")
+        ciphers = credentials.ciphers
+        if ciphers is not None:
+            ssl_ctx.set_cipher_list(ciphers)
+        # Demand a certificate
+        ssl_ctx.set_verify(OpenSSL.SSL.VERIFY_PEER |
+                           OpenSSL.SSL.VERIFY_FAIL_IF_NO_PEER_CERT,
+                           verify_cb)
+        return ssl_ctx
 
-    def makefile(self, mode, bufsize=-1):
-        return fileobject(self.connection, mode, bufsize)
+    # Inspired by
+    # https://github.com/shazow/urllib3/blob/master/urllib3/contrib/pyopenssl.py
+    class RiakWrappedSocket(socket.socket):
+        def __init__(self, connection, socket):
+            """
+            API-compatibility wrapper for Python OpenSSL's Connection-class.
 
-    def settimeout(self, timeout):
-        return self.socket.settimeout(timeout)
+            :param connection: OpenSSL connection
+            :type connection: OpenSSL.SSL.Connection
+            :param socket: Underlying already connected socket
+            :type socket: socket
+            """
+            self.connection = connection
+            self.socket = socket
 
-    def sendall(self, data):
-        # SSL seems to need bytes, so force the data to byte encoding
-        return self.connection.sendall(bytes(data))
+        def fileno(self):
+            return self.socket.fileno()
 
-    def close(self):
-        try:
-            return self.connection.shutdown()
-        except OpenSSL.SSL.Error as err:
-            if err.args == ([],):
-                return False
-            else:
-                raise err
+        def makefile(self, mode, bufsize=-1):
+            return fileobject(self.connection, mode, bufsize)
+
+        def settimeout(self, timeout):
+            return self.socket.settimeout(timeout)
+
+        def sendall(self, data):
+            # SSL seems to need bytes, so force the data to byte encoding
+            return self.connection.sendall(bytes(data))
+
+        def close(self):
+            try:
+                return self.connection.shutdown()
+            except OpenSSL.SSL.Error as err:
+                if err.args == ([],):
+                    return False
+                else:
+                    raise err
 
 
-# Blatantly Stolen from
-# https://github.com/shazow/urllib3/blob/master/urllib3/contrib/pyopenssl.py
-# which is basically a port of the `socket._fileobject` class
-if PY2:
+    # Blatantly Stolen from
+    # https://github.com/shazow/urllib3/blob/master/urllib3/contrib/pyopenssl.py
+    # which is basically a port of the `socket._fileobject` class
     class fileobject(socket._fileobject):
         """
         Extension of the socket module's fileobject to use PyOpenSSL.

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import platform
+import sys
 from setuptools import setup, find_packages
 from version import get_version
 from commands import preconfigure, configure, create_bucket_types, \
@@ -7,16 +7,17 @@ from commands import preconfigure, configure, create_bucket_types, \
 
 install_requires = ['six >= 1.8.0']
 requires = ['six(>=1.8.0)']
-if platform.python_version() < '3.0':
+if sys.version_info < (2, 7, 9):
     install_requires.append("pyOpenSSL >= 0.14")
     requires.append("pyOpenSSL(>=0.14)")
+if sys.version_info < (3, ):
     install_requires.append("riak_pb >=2.0.0")
     requires.append("riak_pb(>=2.0.0)")
 else:
     install_requires.append("python3_riak_pb >=2.0.0")
     requires.append("python3_riak_pb(>=2.0.0)")
 tests_require = []
-if platform.python_version() < '2.7':
+if sys.version_info < (2, 7):
     tests_require.append("unittest2")
 
 setup(


### PR DESCRIPTION
Many enhancements of the Python 3 ssl module have been backported to Python 2.7.9.
In particular, the class `SSLContext()` is available and could be used instead of relying on the pyOpenSSL module. This would avoid the inclusion of a lot of new dependencies: pyopenssl, cryptography, pyasn1, enum34, pycparser, cffi.

I suggest to change [riak/transports/security.py](https://github.com/basho/riak-python-client/blob/2.2.0/riak/transports/security.py) not to use `six.PY2` to decide whether to use the pyOpenSSL, and instead check for the actual availability of `ssl.SSLContext`.