### PR TITLE
Fail fast when deleting datatype directly

### DIFF
--- a/riak/datatypes/datatype.py
+++ b/riak/datatypes/datatype.py
@@ -109,6 +109,9 @@ class Datatype(object):
         Deletes the datatype from Riak. See :meth:`RiakClient.delete()
         <riak.client.RiakClient.delete>` for options.
         """
+        if not self.bucket:
+            raise ValueError('bucket property not assigned')
+
         self.clear()
         self._context = None
         self._set_value(self._default_value())

--- a/riak/tests/test_datatypes.py
+++ b/riak/tests/test_datatypes.py
@@ -136,6 +136,14 @@ class MapUnitTests(DatatypeUnitTests,
                                                  {'adds': ['deep value']})]),
                       op)
 
+    def test_delete_netsed_datatypes(self):
+        dtype = self.dtype(self.bucket, 'key')
+        with self.assertRaises(ValueError):
+            dtype.maps['q'].delete()
+            dtype.registers['q'].delete()
+            dtype.flags['q'].delete()
+            dtype.sets['q'].delete()
+
     def test_removes_require_context(self):
         dtype = self.dtype(self.bucket, 'key')
         with self.assertRaises(datatypes.ContextRequired):


### PR DESCRIPTION
For the sake of clarity.

Now I see this:
```Python
In [23]: m.maps['a'].delete()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-23-f69fd26b29b6> in <module>()
----> 1 m.maps['a'].delete()

/lib/python3.4/site-packages/riak/datatypes/datatype.py in delete(self, **params)
    113         self._context = None
    114         self._set_value(self._default_value())
--> 115         self.bucket._client.delete(self, **params)
    116         return self
    117 

AttributeError: 'NoneType' object has no attribute '_client'
```