### PR TITLE
Upgrade tox version and Python versions

### DIFF
--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -14,9 +14,9 @@ compile:
 	@../setup.py develop
 
 lint:
-	@pip install --upgrade pep8 pyflakes
+	@pip install --upgrade pip pep8 flake8
 	@cd ..; pep8 riak *.py
-	@cd ..; pyflakes riak *.py
+	@cd ..; flake8 riak *.py
 	@openssl verify -CAfile ${CERTS_DIR}/ca.crt ${CERTS_DIR}/client.crt
 	@openssl verify -CAfile ${CERTS_DIR}/ca.crt ${CERTS_DIR}/server.crt
 

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -3,6 +3,7 @@ RIAK_CONF = ${RIAK_DIR}/etc/riak.conf
 # RIAK = ${RIAK_DIR}/bin/riak
 RIAK_ADMIN = ${RIAK_DIR}/bin/riak-admin
 CERTS_DIR = $(shell pwd)/../riak/tests/resources
+unexport PYENV_VERSION
 
 preconfigure:
 	@../setup.py preconfigure --riak-conf=${RIAK_CONF}
@@ -14,7 +15,7 @@ compile:
 	@../setup.py develop
 
 lint:
-	@pip install --upgrade pip pep8 flake8
+	@pip install --upgrade pep8 flake8
 	@cd ..; pep8 riak *.py
 	@cd ..; flake8 riak *.py
 	@openssl verify -CAfile ${CERTS_DIR}/ca.crt ${CERTS_DIR}/client.crt

--- a/buildbot/tox_setup.sh
+++ b/buildbot/tox_setup.sh
@@ -22,22 +22,25 @@ if [[ ! -d $PYENV_ROOT ]]; then
     eval "$(pyenv virtualenv-init -)"
 
     # Now load up (allthethings)
-    VERSION_ALIAS="riak_2.6.9" pyenv install 2.6.9
-    VERSION_ALIAS="riak_2.7.9" pyenv install 2.7.9
+    VERSION_ALIAS="riak_3.4.3" pyenv install 3.4.3
     VERSION_ALIAS="riak_3.3.6" pyenv install 3.3.6
-    VERSION_ALIAS="riak_3.4.2" pyenv install 3.4.2
+    VERSION_ALIAS="riak_2.7.10" pyenv install 2.7.10
+    VERSION_ALIAS="riak_2.7.9" pyenv install 2.7.9
+    VERSION_ALIAS="riak_2.6.9" pyenv install 2.6.9
 
-    pyenv virtualenv riak_2.6.9 riak-py26
-    pyenv virtualenv riak_2.7.9 riak-py27
+    pyenv virtualenv riak_3.4.3 riak-py34
     pyenv virtualenv riak_3.3.6 riak-py33
-    pyenv virtualenv riak_3.4.2 riak-py34
-    pyenv global riak-py26 riak-py27 riak-py33 riak-py34
+    pyenv virtualenv riak_2.7.10 riak-py27
+    pyenv virtualenv riak_2.7.9 riak-py279
+    pyenv virtualenv riak_2.6.9 riak-py26
+    pyenv global riak-py34 riak-py33 riak-py27 riak-py279 riak-py26
     pyenv versions
 fi
 
 # Now install tox
+pip install --upgrade pip
 if [ -z "`pip show tox`" ]; then
-    pip install -Iv tox=1.9.0
+    pip install -Iv tox
     if [ -z "`pip show tox`" ]; then
         echo "ERROR: Install of tox failed"
         exit 1

--- a/buildbot/tox_setup.sh
+++ b/buildbot/tox_setup.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # pyenv root
 export PYENV_ROOT="$HOME/.pyenv"
+TEST_ROOT=$PWD/..
 
 # Install pyenv if it's missing
 if [[ ! -d $PYENV_ROOT ]]; then
@@ -8,33 +9,58 @@ if [[ ! -d $PYENV_ROOT ]]; then
     cd ${PYENV_ROOT}
     # Get the latest tagged version
     git checkout `git tag | tail -1`
-    git clone https://github.com/yyuu/pyenv-virtualenv.git ${PYENV_ROOT}/plugins/pyenv-virtualenv
-    cd plugins/pyenv-virtualenv
-    git checkout `git tag | tail -1`
-    git clone https://github.com/s1341/pyenv-alias.git ${PYENV_ROOT}/plugins/pyenv-alias
-
-    # Add pyenv root to PATH
-    # and initialize pyenv
-    PATH="$PYENV_ROOT/bin:$PATH"
-    # initialize pyenv
-    eval "$(pyenv init -)"
-    # initialize pyenv virtualenv
-    eval "$(pyenv virtualenv-init -)"
-
-    # Now load up (allthethings)
-    VERSION_ALIAS="riak_3.4.3" pyenv install 3.4.3
-    VERSION_ALIAS="riak_3.3.6" pyenv install 3.3.6
-    VERSION_ALIAS="riak_2.7.10" pyenv install 2.7.10
-    VERSION_ALIAS="riak_2.7.9" pyenv install 2.7.9
-    VERSION_ALIAS="riak_2.6.9" pyenv install 2.6.9
-
-    pyenv virtualenv riak_3.4.3 riak-py34
-    pyenv virtualenv riak_3.3.6 riak-py33
-    pyenv virtualenv riak_2.7.10 riak-py27
-    pyenv virtualenv riak_2.7.9 riak-py279
-    pyenv virtualenv riak_2.6.9 riak-py26
-    pyenv versions
 fi
+
+# Upgrade it, if it's too old
+if [[ -z $(pyenv install --list | grep 3.4.3) ]]; then
+    cd ${PYENV_ROOT}
+    git pull origin master
+    git pull -u origin master
+    # Get the latest tagged version
+    git checkout `git tag | tail -1`
+fi
+
+if [[ ! -d ${PYENV_ROOT}/plugins/pyenv-virtualenv ]]; then
+    git clone https://github.com/yyuu/pyenv-virtualenv.git ${PYENV_ROOT}/plugins/pyenv-virtualenv
+    cd ${PYENV_ROOT}/plugins/pyenv-virtualenv
+    git checkout `git tag | tail -1`
+fi
+
+if [[ ! -d ${PYENV_ROOT}/plugins/pyenv-alias ]]; then
+    git clone https://github.com/s1341/pyenv-alias.git ${PYENV_ROOT}/plugins/pyenv-alias
+fi
+
+# Add pyenv root to PATH
+# and initialize pyenv
+PATH="$PYENV_ROOT/bin:$PATH"
+# initialize pyenv
+eval "$(pyenv init -)"
+# initialize pyenv virtualenv
+eval "$(pyenv virtualenv-init -)"
+
+# Now install (allthethings) versions for testing
+if [[ -z $(pyenv versions | grep riak_3.4.3) ]]; then
+    VERSION_ALIAS="riak_3.4.3" pyenv install 3.4.3
+    pyenv virtualenv riak_3.4.3 riak-py34
+fi
+if [[ -z $(pyenv versions | grep riak_3.3.6) ]]; then
+    VERSION_ALIAS="riak_3.3.6" pyenv install 3.3.6
+    pyenv virtualenv riak_3.3.6 riak-py33
+fi
+if [[ -z $(pyenv versions | grep riak_2.7.10) ]]; then
+    VERSION_ALIAS="riak_2.7.10" pyenv install 2.7.10
+    pyenv virtualenv riak_2.7.10 riak-py27
+fi
+if [[ -z $(pyenv versions | grep riak_2.7.9) ]]; then
+    VERSION_ALIAS="riak_2.7.9" pyenv install 2.7.9
+    pyenv virtualenv riak_2.7.9 riak-py279
+fi
+if [[ -z $(pyenv versions | grep riak_2.6.9) ]]; then
+    VERSION_ALIAS="riak_2.6.9" pyenv install 2.6.9
+    pyenv virtualenv riak_2.6.9 riak-py26
+fi
+pyenv global riak-py34 riak-py33 riak-py27 riak-py279 riak-py26
+pyenv versions
 
 # Now install tox
 pip install --upgrade pip

--- a/buildbot/tox_setup.sh
+++ b/buildbot/tox_setup.sh
@@ -33,7 +33,6 @@ if [[ ! -d $PYENV_ROOT ]]; then
     pyenv virtualenv riak_2.7.10 riak-py27
     pyenv virtualenv riak_2.7.9 riak-py279
     pyenv virtualenv riak_2.6.9 riak-py26
-    pyenv global riak-py34 riak-py33 riak-py27 riak-py279 riak-py26
     pyenv versions
 fi
 

--- a/riak/bucket.py
+++ b/riak/bucket.py
@@ -52,12 +52,13 @@ class RiakBucket(object):
         :param bucket_type: The parent bucket type of this bucket
         :type bucket_type: :class:`BucketType`
         """
+
+        if not isinstance(name, string_types):
+            raise TypeError('Bucket name must be a string')
+
         if PY2:
             try:
-                if isinstance(name, string_types):
-                        name = name.encode('ascii')
-                else:
-                    raise TypeError('Bucket name must be a string')
+                name = name.encode('ascii')
             except UnicodeError:
                 raise TypeError('Unicode bucket names are not supported.')
 

--- a/riak/client/operations.py
+++ b/riak/client/operations.py
@@ -914,7 +914,7 @@ class RiakClientOperations(RiakClientTransport):
         :type returnvalue: bool
         """
         if PY2:
-            valid_types = (int, long)
+            valid_types = (int, long)  # noqa
         else:
             valid_types = (int,)
         if type(value) not in valid_types:
@@ -1073,6 +1073,6 @@ def _validate_timeout(timeout):
     Raises an exception if the given timeout is an invalid value.
     """
     if not (timeout is None or
-            ((type(timeout) == int or (PY2 and type(timeout) == long)) and
-             timeout > 0)):
+            ((type(timeout) == int or
+             (PY2 and type(timeout) == long)) and timeout > 0)):  # noqa
         raise ValueError("timeout must be a positive integer")

--- a/riak/datatypes/counter.py
+++ b/riak/datatypes/counter.py
@@ -73,7 +73,7 @@ class Counter(Datatype):
 
     def _check_type(self, new_value):
         return (isinstance(new_value, int) or
-                isinstance(new_value, long))
+                isinstance(new_value, long))  # noqa
 
 
 TYPES['counter'] = Counter

--- a/riak/test_server.py
+++ b/riak/test_server.py
@@ -31,8 +31,8 @@ class Atom(object):
     def __eq__(self, other):
         return self.str == other
 
-    def __cmp__(self, other):
-        return cmp(self.str, other)
+    def __lt__(self, other):
+        return self.str < other
 
 
 def erlang_config(hash, depth=1):

--- a/riak/tests/test_all.py
+++ b/riak/tests/test_all.py
@@ -298,7 +298,7 @@ class ClientTests(object):
             self.assertEqual(failure[1], self.bucket_name)
             self.assertIn(failure[2], keys)
             if PY2:
-                self.assertIsInstance(failure[3], StandardError)
+                self.assertIsInstance(failure[3], StandardError)  # noqa
             else:
                 self.assertIsInstance(failure[3], Exception)
 

--- a/riak/tests/test_kv.py
+++ b/riak/tests/test_kv.py
@@ -147,9 +147,8 @@ class BasicKVTests(object):
             with self.assert_raises_regex(TypeError, 'must be a string'):
                 self.client.bucket(bad)
 
-            if PY2:
-                with self.assert_raises_regex(TypeError, 'must be a string'):
-                    RiakBucket(self.client, bad, None)
+            with self.assert_raises_regex(TypeError, 'must be a string'):
+                RiakBucket(self.client, bad, None)
 
         # Unicode bucket names are not supported in Python 2.x,
         # if they can't be encoded to ASCII. This should be changed in a
@@ -192,6 +191,9 @@ class BasicKVTests(object):
 
     def test_stream_keys_timeout(self):
         bucket = self.client.bucket('random_key_bucket')
+        for key in range(1,1000):
+            o = bucket.new(None, data={})
+            o.store()
         streamed_keys = []
         with self.assertRaises(RiakError):
             for keylist in self.client.stream_keys(bucket, timeout=1):

--- a/riak/tests/test_kv.py
+++ b/riak/tests/test_kv.py
@@ -89,7 +89,7 @@ class BasicKVTests(object):
         # unicode objects are fine, as long as they don't
         # contain any non-ASCII chars
         if PY2:
-            self.client.bucket(unicode(self.bucket_name))
+            self.client.bucket(unicode(self.bucket_name))  # noqa
         else:
             self.client.bucket(self.bucket_name)
         if PY2:
@@ -191,7 +191,7 @@ class BasicKVTests(object):
 
     def test_stream_keys_timeout(self):
         bucket = self.client.bucket('random_key_bucket')
-        for key in range(1,1000):
+        for key in range(1, 1000):
             o = bucket.new(None, data={})
             o.store()
         streamed_keys = []

--- a/riak/tests/test_six.py
+++ b/riak/tests/test_six.py
@@ -129,8 +129,8 @@ class Comparison(object):
                 diffMsg = '\n'.join(lines)
                 standardMsg = self._truncateMessage(standardMsg, diffMsg)
 
-    def assert_raises_regex(self, exception, regexp, msg=None):
+    def assert_raises_regex(self, exception, regexp):
         if PY2:
-            return self.assertRaisesRegexp(exception, regexp, msg)
+            return self.assertRaisesRegexp(exception, regexp)
         else:
-            return self.assertRaisesRegex(exception, regexp, msg)
+            return self.assertRaisesRegex(exception, regexp)

--- a/riak/transports/http/resources.py
+++ b/riak/transports/http/resources.py
@@ -264,7 +264,7 @@ def mkpath(*segments, **query):
         if query[key] in [False, True]:
             _query[key] = str(query[key]).lower()
         elif query[key] is not None:
-            if PY2 and isinstance(query[key], unicode):
+            if PY2 and isinstance(query[key], unicode):  # noqa
                 _query[key] = query[key].encode('utf-8')
             else:
                 _query[key] = query[key]

--- a/riak/transports/pbc/codec.py
+++ b/riak/transports/pbc/codec.py
@@ -510,8 +510,8 @@ class RiakPbcCodec(object):
         resultdoc = MultiDict()
         for pair in doc.fields:
             if PY2:
-                ukey = unicode(pair.key, 'utf-8')
-                uval = unicode(pair.value, 'utf-8')
+                ukey = unicode(pair.key, 'utf-8')    # noqa
+                uval = unicode(pair.value, 'utf-8')  # noqa
             else:
                 ukey = bytes_to_str(pair.key)
                 uval = bytes_to_str(pair.value)

--- a/riak/transports/pbc/transport.py
+++ b/riak/transports/pbc/transport.py
@@ -565,7 +565,7 @@ class RiakPbcTransport(RiakTransport, RiakPbcConnection, RiakPbcCodec):
         if not self.pb_search():
             return self._search_mapred_emu(index, query)
 
-        if PY2 and isinstance(query, unicode):
+        if PY2 and isinstance(query, unicode):  # noqa
             query = query.encode('utf8')
 
         req = riak_pb.RpbSearchQueryReq(index=str_to_bytes(index),

--- a/riak/util.py
+++ b/riak/util.py
@@ -113,6 +113,6 @@ def str_to_long(value, base=10):
     if value is None:
         return None
     elif PY2:
-        return long(value, base)
+        return long(value, base)  # noqa
     else:
         return int(value, base)

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@
 envlist = py26, py279, py27, py33, py34
 
 [testenv]
+install_command = pip install --upgrade {packages}
 commands = {envpython} setup.py test
 deps = six
+       pip
 passenv = RUN_* SKIP_* RIAK_*

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,9 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py26, py279, py27, py33, py34
 
 [testenv]
 commands = {envpython} setup.py test
 deps = six
+passenv = RUN_* SKIP_* RIAK_*


### PR DESCRIPTION
- Add Python 2.7.9, Python 2.7.10 and Python 3.4.3
- Allow **tox** to be upgraded to latest version (2.1.1)
- Fix `test_string_bucket_name`
- Fix `test_stream_keys_timeout`  to have many more keys to stream
- Use `flake8` instead of `pyflakes` for lint testing
- Use `#noqa` lines to allow lint testing under Python 3
- Unset the `PYENV_VERSION` variable to use non-buildbot versions of Python