### PR TITLE
Speed up buildbot integration

### DIFF
--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -34,8 +34,8 @@ test_normal:
 test_security:
 	@echo "Testing Riak Python Client (with security)"
 	@../setup.py enable_security --riak-admin=$(RIAK_ADMIN)
-	@RIAK_TEST_PROTOCOL='pbc' RUN_YZ=1 RUN_INDEXES=1 RUN_SECURITY=1 RUN_POOL=0 RUN_RESOLVE=0 ./tox_runner.sh ..
-	@RIAK_TEST_PROTOCOL='http' RUN_YZ=1 RUN_INDEXES=1 RUN_SECURITY=1 RUN_POOL=0 RUN_RESOLVE=0 RIAK_TEST_HTTP_PORT=18098 ./tox_runner.sh ..
+	@RIAK_TEST_PROTOCOL='pbc' RUN_YZ=1 RUN_INDEXES=1 RUN_SECURITY=1 RUN_POOL=0 RUN_RESOLVE=0 ./tox_runner.sh .. --test-suite=riak.tests.test_security
+	@RIAK_TEST_PROTOCOL='http' RUN_YZ=1 RUN_INDEXES=1 RUN_SECURITY=1 RUN_POOL=0 RUN_RESOLVE=0 RIAK_TEST_HTTP_PORT=18098 ./tox_runner.sh .. --test-suite=riak.tests.test_security
 
 test_timeseries:
 	@echo "Testing Riak Python Client (timeseries)"

--- a/buildbot/tox_runner.sh
+++ b/buildbot/tox_runner.sh
@@ -1,17 +1,12 @@
 #!/usr/bin/env bash
-# pyenv root
 export PYENV_ROOT="$HOME/.pyenv"
-
-# Add pyenv root to PATH
-# and initialize pyenv
-PATH="$PYENV_ROOT/bin:$PATH"
-# initialize pyenv
+export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"
-# initialize pyenv virtualenv
 eval "$(pyenv virtualenv-init -)"
 
-# Change directory if an argument is passed in
 if [[ ! -z "$1" ]]; then
     cd "$1"
+    shift
 fi
-tox
+
+tox -- $@

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ basepython = {env:HOME}/.pyenv/versions/riak-py278/bin/python2.7
 
 [testenv]
 install_command = pip install --upgrade {packages}
-commands = {envpython} setup.py test
+commands = {envpython} setup.py test {posargs:DEFAULTS}
 deps = six
        pip
 passenv = RUN_* SKIP_* RIAK_*


### PR DESCRIPTION
Modify test_security buildbot target to only run the `riak.tests.test_security` suite