### PR TITLE
Fix for riak per bucket replication settings encoding in protobuf

### DIFF
--- a/riak/transports/pbc/codec.py
+++ b/riak/transports/pbc/codec.py
@@ -295,7 +295,7 @@ class RiakPbcCodec(object):
                     else:
                         setattr(msg.props, prop, value)
         if 'repl' in props:
-            msg.props.repl = REPL_TO_PY[props['repl']]
+            msg.props.repl = REPL_TO_PB[props['repl']]
 
         return msg
 


### PR DESCRIPTION
Hi,

Seems like due to typo codec function is not working correctly. 

If one wants to set per bucket replication settings, _encode_bucket_props function will try to convert to python notation instead of PB -> msg.props.repl won't accept the result -> function fails.

Cheers,
Vitaly