### PR TITLE
README.md is UTF-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ try:
     import pypandoc
     long_description = pypandoc.convert('README.md', 'rst')
 except(IOError, ImportError):
-    long_description = open('README.md').read()
+    long_description = open('README.md', encoding='UTF-8').read()
 
 setup(
     name='riak',


### PR DESCRIPTION
setup failure with python3
~~~
% python setup.py build
Traceback (most recent call last):
  File "setup.py", line 26, in <module>
    import pypandoc
ImportError: No module named 'pypandoc'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "setup.py", line 29, in <module>
    long_description = open('README.md').read()
  File "/home/hamano/git/riak-python-client/venv/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 5207: ordinal not in range(128)
~~~