### PR TITLE
Don't use six.PY2 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import codecs
-import six
 import sys
 
 from setuptools import setup, find_packages
@@ -15,7 +14,7 @@ if sys.version_info[0:3] <= (2, 7, 9):
     install_requires.append("pyOpenSSL >= 0.14")
     requires.append("pyOpenSSL(>=0.14)")
 
-if six.PY2:
+if sys.version_info[0:3] <= (3, 0, 0):
     install_requires.append('protobuf >=2.4.1, <2.7.0')
     requires.append('protobuf(>=2.4.1, <2.7.0)')
 else:


### PR DESCRIPTION
six is not guaranteed to be installed before running pip/setuptools.
The client fails to install on a machine or fresh virtualenv
without six with errors like the following:

```
; virtualenv ve
; ./ve/bin/pip install riak
Collecting riak
  Downloading riak-2.5.0.tar.gz (193kB)
    100% |████████████████████████████████| 196kB 9.2MB/s
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-ReAmHf/riak/setup.py", line 4, in <module>
        import six
    ImportError: No module named six
```

This snuck past tox testing, because six is listed as an explict
dependency in tox.ini.

I tried testing the changes locally, but ran into another six related problem in basho-erlastic, which I filed an issue for.  basho/python-erlastic#2