### PR TITLE
Handle creation of tables via SQL

### DIFF
--- a/riak/codecs/ttb.py
+++ b/riak/codecs/ttb.py
@@ -181,7 +181,7 @@ class TtbCodec(Codec):
                 raise RiakError(
                     "Expected 3-tuple in response, got: {}".format(resp_data))
         else:
-            raise RiakError("Unknown TTB response type: {}".format(resp_ttb))
+            raise RiakError("Unknown TTB response type: {}".format(resp_a))
 
     def decode_timeseries_cols(self, cnames, ctypes):
         cnames = [bytes_to_str(cname) for cname in cnames]

--- a/riak/codecs/ttb.py
+++ b/riak/codecs/ttb.py
@@ -154,7 +154,10 @@ class TtbCodec(Codec):
         self.maybe_err_ttb(resp_ttb)
 
         resp_a = resp_ttb[0]
-        if resp_a == tsputresp_a:
+
+        if resp_ttb == tsqueryresp_a:
+            return tsobj
+        elif resp_a == tsputresp_a:
             return
         elif resp_a == tsgetresp_a or resp_a == tsqueryresp_a:
             resp_data = resp_ttb[1]
@@ -175,7 +178,7 @@ class TtbCodec(Codec):
                 raise RiakError(
                     "Expected 3-tuple in response, got: {}".format(resp_data))
         else:
-            raise RiakError("Unknown TTB response type: {}".format(resp_a))
+            raise RiakError("Unknown TTB response type: {}".format(resp_ttb))
 
     def decode_timeseries_cols(self, cnames, ctypes):
         cnames = [bytes_to_str(cname) for cname in cnames]

--- a/riak/codecs/ttb.py
+++ b/riak/codecs/ttb.py
@@ -153,11 +153,14 @@ class TtbCodec(Codec):
 
         self.maybe_err_ttb(resp_ttb)
 
-        resp_a = resp_ttb[0]
-
+        # NB: some queries return a BARE 'tsqueryresp' atom
+        # catch that here:
         if resp_ttb == tsqueryresp_a:
             return tsobj
-        elif resp_a == tsputresp_a:
+
+        # The response atom is the first element in the response tuple
+        resp_a = resp_ttb[0]
+        if resp_a == tsputresp_a:
             return
         elif resp_a == tsgetresp_a or resp_a == tsqueryresp_a:
             resp_data = resp_ttb[1]

--- a/riak/tests/test_timeseries_ttb.py
+++ b/riak/tests/test_timeseries_ttb.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 import datetime
-import random
-import string
 import logging
 import six
 import unittest
@@ -133,9 +131,7 @@ class TimeseriesTtbTests(IntegrationTestBase, unittest.TestCase):
         super(TimeseriesTtbTests, cls).setUpClass()
 
     def test_query_that_creates_table_using_interpolation(self):
-        table = ''.join(
-            [random.choice(string.ascii_letters + string.digits)
-                for n in range(32)])
+        table = self.randname()
         query = """CREATE TABLE test-{table} (
             geohash varchar not null,
             user varchar not null,

--- a/riak/tests/test_timeseries_ttb.py
+++ b/riak/tests/test_timeseries_ttb.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
+import random
+import string
 import logging
 import six
 import unittest
@@ -129,6 +131,24 @@ class TimeseriesTtbTests(IntegrationTestBase, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(TimeseriesTtbTests, cls).setUpClass()
+
+    def test_query_that_creates_table_using_interpolation(self):
+        table = ''.join(
+            [random.choice(string.ascii_letters + string.digits)
+                for n in range(32)])
+        query = """CREATE TABLE test-{table} (
+            geohash varchar not null,
+            user varchar not null,
+            time timestamp not null,
+            weather varchar not null,
+            temperature double,
+            PRIMARY KEY((geohash, user, quantum(time, 15, m)),
+                geohash, user, time))
+        """
+        ts_obj = self.client.ts_query(table, query)
+        self.assertIsNotNone(ts_obj)
+        self.assertFalse(hasattr(ts_obj, 'ts_cols'))
+        self.assertIsNone(ts_obj.rows)
 
     def test_query_that_returns_table_description(self):
         fmt = 'DESCRIBE {table}'


### PR DESCRIPTION
This issue was found when running the `riak_demo` for time series.  Basically `create table` was handing back an empty query response.

```
RiakErrorTraceback (most recent call last)
<ipython-input-3-23aaf27844ac> in <module>()
     14             )
     15 """
---> 16 c.ts_query('aarhus2',fmt)

/home/vagrant/ts-demo/local/lib/python2.7/site-packages/riak/client/transport.pyc in wrapper(self, *args, **kwargs)
    177             return fn(self, transport, *args, **kwargs)
    178 
--> 179         return self._with_retries(pool, thunk)
    180 
    181     wrapper.__doc__ = fn.__doc__

/home/vagrant/ts-demo/local/lib/python2.7/site-packages/riak/client/transport.pyc in _with_retries(self, pool, fn)
    119                 with pool.transaction(_filter=_skip_bad_nodes) as transport:
    120                     try:
--> 121                         return fn(transport)
    122                     except (IOError, HTTPException) as e:
    123                         if _is_retryable(e):

/home/vagrant/ts-demo/local/lib/python2.7/site-packages/riak/client/transport.pyc in thunk(transport)
    175 
    176         def thunk(transport):
--> 177             return fn(self, transport, *args, **kwargs)
    178 
    179         return self._with_retries(pool, thunk)

/home/vagrant/ts-demo/local/lib/python2.7/site-packages/riak/client/operations.pyc in ts_query(self, transport, table, query, interpolations)
    634         if isinstance(t, string_types):
    635             t = Table(self, table)
--> 636         return transport.ts_query(t, query, interpolations)
    637 
    638     def ts_stream_keys(self, table, timeout=None):

/home/vagrant/ts-demo/local/lib/python2.7/site-packages/riak/transports/tcp/transport.pyc in ts_query(self, table, query, interpolations)
    183         tsobj = TsObject(self._client, table)
    184         codec.decode_timeseries(resp, tsobj,
--> 185                                 self._ts_convert_timestamp)
    186         return tsobj
    187 

/home/vagrant/ts-demo/local/lib/python2.7/site-packages/riak/codecs/ttb.pyc in decode_timeseries(self, resp_ttb, tsobj, convert_timestamp)
    179                     "Expected 3-tuple in response, got: {}".format(resp_data))
    180         else:
--> 181             raise RiakError("Unknown TTB response type: {}".format(resp_a))
    182 
    183     def decode_timeseries_cols(self, cnames, ctypes):

RiakError: 'Unknown TTB response type: t'
```  