### PR TITLE
open `readme.md` with codecs.open

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ try:
     with codecs.open('README.rst', 'w', 'utf-8') as f:
         f.write(long_description)
 except(IOError, ImportError):
-    with open('README.md') as f:
+    with codecs.open('README.md', 'r', 'utf-8') as f:
         long_description = f.read()
 
 setup(


### PR DESCRIPTION
We were installing the package on a machine when this happened:

```
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "/tmp/pip-build-6jkee90k/riak/setup.py", line 25, in <module>
        import pypandoc
    ImportError: No module named 'pypandoc'
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-6jkee90k/riak/setup.py", line 31, in <module>
        long_description = f.read()
      File "/venv/bme/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 5207: ordinal not in range(128)
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-6jkee90k/riak
```

I think this might fix the error.