### PR TITLE
Use default Python file encoding during test / release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,18 @@
-.PHONY: pb_clean pb_compile pb_build release release_sdist
+.PHONY: pb_clean pb_compile pb_build release release_sdist test_sdist
+
+unexport LANG
+unexport LC_ADDRESS
+unexport LC_COLLATE
+unexport LC_CTYPE
+unexport LC_IDENTIFICATION
+unexport LC_MEASUREMENT
+unexport LC_MESSAGES
+unexport LC_MONETARY
+unexport LC_NAME
+unexport LC_NUMERIC
+unexport LC_PAPER
+unexport LC_TELEPHONE
+unexport LC_TIME
 
 PANDOC_VERSION := $(shell pandoc --version)
 
@@ -12,6 +26,9 @@ pb_compile: pb_clean
 	@echo "==> Python (compile)"
 	@protoc -Iriak_pb/src --python_out=riak/pb riak_pb/src/*.proto
 	@python setup.py build_messages
+
+test_sdist:
+	@python setup.py sdist
 
 release_sdist:
 ifeq ($(VERSION),)

--- a/buildbot/Makefile
+++ b/buildbot/Makefile
@@ -3,6 +3,19 @@ $(error RIAK_DIR is not set)
 endif
 
 unexport PYENV_VERSION
+unexport LANG
+unexport LC_ADDRESS
+unexport LC_COLLATE
+unexport LC_CTYPE
+unexport LC_IDENTIFICATION
+unexport LC_MEASUREMENT
+unexport LC_MESSAGES
+unexport LC_MONETARY
+unexport LC_NAME
+unexport LC_NUMERIC
+unexport LC_PAPER
+unexport LC_TELEPHONE
+unexport LC_TIME
 
 PROJDIR = $(realpath $(CURDIR)/..)
 TOOLS_DIR = $(PROJDIR)/tools/devrel

--- a/riak/security.py
+++ b/riak/security.py
@@ -254,7 +254,7 @@ class SecurityCreds:
                 if not isinstance(key_file, list):
                     key_file = [key_file]
                 for filename in key_file:
-                    with open(filename, 'r') as f:
+                    with open(filename, 'rb') as f:
                         cert_list.append(loader(OpenSSL.SSL.FILETYPE_PEM,
                                                 f.read()))
                 # If it is not a list, just store the first element

--- a/setup.py
+++ b/setup.py
@@ -21,14 +21,16 @@ else:
     install_requires.append('python3_protobuf >=2.4.1, <2.6.0')
     requires.append('python3_protobuf(>=2.4.1, <2.6.0)')
 
+with codecs.open('README.md', 'r', 'utf-8') as f:
+    readme_md = f.read()
+
 try:
     import pypandoc
     long_description = pypandoc.convert('README.md', 'rst')
     with codecs.open('README.rst', 'w', 'utf-8') as f:
         f.write(long_description)
 except(IOError, ImportError):
-    with codecs.open('README.md', 'r', 'utf-8') as f:
-        long_description = f.read()
+    long_description = readme_md
 
 setup(
     name='riak',

--- a/version.py
+++ b/version.py
@@ -80,7 +80,8 @@ def get_version():
 
     else:
         # Extract the version from the PKG-INFO file.
-        with open(join(d, 'PKG-INFO')) as f:
+        import codecs
+        with codecs.open(join(d, 'PKG-INFO'), 'r', 'utf-8') as f:
             version = version_re.search(f.read()).group(1)
 
     return version


### PR DESCRIPTION
Unexport vars related to encoding, ensure files are opened with utf-8 when necessary.

Fixes #476 (CLIENTS-864) 
Addresses #474