### PR TITLE
Add fix for old Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Repository Cloning
 Install
 =======
 
-The recommended versions of Python for use with this client are Python `2.7.x`, `3.3.x`, `3.4.x` and `3.5.x`. The latest version from each series should be preferred.
+The recommended versions of Python for use with this client are Python `2.7.8` (or greater, `2.7.11` as of `2016-06-21`), `3.3.x`, `3.4.x` and `3.5.x`. The latest version from each series should be preferred. Older versions of the Python `2.7.X` and `3.X` series should be used with caution as they are not covered by integration tests.
 
 Riak TS (Timeseries)
 ===================

--- a/riak/transports/tcp/connection.py
+++ b/riak/transports/tcp/connection.py
@@ -19,6 +19,9 @@ else:
 
 
 class TcpConnection(object):
+    def __init__(self):
+        self.bytes_required = False
+
     """
     Connection-related methods for TcpTransport.
     """
@@ -163,12 +166,16 @@ class TcpConnection(object):
             # https://github.com/basho/riak-python-client/issues/425
             raise BadResource(e)
         mv = memoryview(msgbuf)
+        mcb = mv[0:1]
+        if self.bytes_required:
+            mcb = mcb.tobytes()
         try:
-            msg_code, = struct.unpack("B", mv[0:1])
+            msg_code, = struct.unpack("B", mcb)
         except struct.error:
             # NB: Python 2.7.3 requires this
             # http://bugs.python.org/issue10212
             msg_code, = struct.unpack("B", mv[0:1].tobytes())
+            self.bytes_required = True
         data = mv[1:].tobytes()
         return (msg_code, data)
 
@@ -176,12 +183,15 @@ class TcpConnection(object):
         # TODO FUTURE re-use buffer
         msglen_buf = self._recv(4)
         # NB: msg length is an unsigned int
+        if self.bytes_required:
+            msglen_buf = bytes(msglen_buf)
         try:
             msglen, = struct.unpack('!I', msglen_buf)
         except struct.error:
             # NB: Python 2.7.3 requires this
             # http://bugs.python.org/issue10212
             msglen, = struct.unpack('!I', bytes(msglen_buf))
+            self.bytes_required = True
         return self._recv(msglen)
 
     def _recv(self, msglen):


### PR DESCRIPTION
When pinging Riak using Python 2.7.3, you see this:

```
Python 2.7.3 (default, Jun 22 2015, 19:33:41)
[GCC 4.6.3] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import riak
/usr/local/lib/python2.7/dist-packages/riak/security.py:45: UserWarning: OpenSSL 1.0.1 14 Mar 2012 (>= 1.0.1g required), TLS 1.2 support: False
  warnings.warn(msg, UserWarning)
>>> nodes = [{'host':'192.168.161.134','pb_port': 10017,'http_port': 10018}]
>>> nodes
[{'host': '192.168.161.134', 'pb_port': 10017, 'http_port': 10018}]
>>> c = riak.RiakClient(protocol='pbc',nodes=nodes)
>>> c.ping()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/riak/client/transport.py", line 179, in wrapper
    return self._with_retries(pool, thunk)
  File "/usr/local/lib/python2.7/dist-packages/riak/client/transport.py", line 121, in _with_retries
    return fn(transport)
  File "/usr/local/lib/python2.7/dist-packages/riak/client/transport.py", line 177, in thunk
    return fn(self, transport, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/riak/client/operations.py", line 120, in ping
    return transport.ping()
  File "/usr/local/lib/python2.7/dist-packages/riak/transports/tcp/transport.py", line 88, in ping
    codec = self._get_codec(msg_code)
  File "/usr/local/lib/python2.7/dist-packages/riak/transports/tcp/transport.py", line 75, in _get_codec
    codec = self._get_pbuf_codec()
  File "/usr/local/lib/python2.7/dist-packages/riak/transports/tcp/transport.py", line 52, in _get_pbuf_codec
    self.client_timeouts(), self.quorum_controls(),
  File "/usr/local/lib/python2.7/dist-packages/riak/transports/feature_detect.py", line 163, in client_timeouts
    return self.server_version >= versions[1.4]
  File "/usr/local/lib/python2.7/dist-packages/riak/util.py", line 89, in __get__
    value = self.fget(obj)
  File "/usr/local/lib/python2.7/dist-packages/riak/transports/feature_detect.py", line 215, in server_version
    return LooseVersion(self._server_version())
  File "/usr/local/lib/python2.7/dist-packages/riak/transports/tcp/transport.py", line 80, in _server_version
    server_info = self.get_server_info()
  File "/usr/local/lib/python2.7/dist-packages/riak/transports/tcp/transport.py", line 105, in get_server_info
    resp_code, resp = self._request(msg, codec)
  File "/usr/local/lib/python2.7/dist-packages/riak/transports/tcp/transport.py", line 537, in _request
    resp_code, data = self._send_recv(msg_code, data)
  File "/usr/local/lib/python2.7/dist-packages/riak/transports/tcp/connection.py", line 33, in _send_recv
    return self._recv_msg()
  File "/usr/local/lib/python2.7/dist-packages/riak/transports/tcp/connection.py", line 158, in _recv_msg
    msgbuf = self._recv_pkt()
  File "/usr/local/lib/python2.7/dist-packages/riak/transports/tcp/connection.py", line 174, in _recv_pkt
    msglen, = struct.unpack('!I', msglen_buf)
struct.error: unpack requires a string argument of length 4
```

The comments in the code explain why.