### PR TITLE
Calculate unix timestamp using timezone if present

### DIFF
--- a/riak/tests/test_datetime.py
+++ b/riak/tests/test_datetime.py
@@ -3,8 +3,7 @@ import datetime
 import unittest
 
 from riak.util import epoch, epoch_tz, \
-        unix_time_millis, \
-        datetime_from_unix_time_millis
+        unix_time_millis
 
 # NB: without tzinfo, this is UTC
 ts0 = datetime.datetime(2015, 1, 1, 12, 1, 2, 987000)
@@ -15,6 +14,7 @@ ts0_ts_pst = 1420142462987
 class DatetimeUnitTests(unittest.TestCase):
     def test_get_unix_time_without_tzinfo(self):
         self.assertIsNone(epoch.tzinfo)
+        self.assertIsNotNone(epoch_tz.tzinfo)
         self.assertIsNone(ts0.tzinfo)
         utm = unix_time_millis(ts0)
         self.assertEqual(utm, ts0_ts)

--- a/riak/tests/test_datetime.py
+++ b/riak/tests/test_datetime.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+import datetime
+import unittest
+
+from riak.util import epoch, epoch_tz, \
+        unix_time_millis, \
+        datetime_from_unix_time_millis
+
+# NB: without tzinfo, this is UTC
+ts0 = datetime.datetime(2015, 1, 1, 12, 1, 2, 987000)
+ts0_ts = 1420113662987
+ts0_ts_pst = 1420142462987
+
+
+class DatetimeUnitTests(unittest.TestCase):
+    def test_get_unix_time_without_tzinfo(self):
+        self.assertIsNone(epoch.tzinfo)
+        self.assertIsNone(ts0.tzinfo)
+        utm = unix_time_millis(ts0)
+        self.assertEqual(utm, ts0_ts)
+
+    def test_get_unix_time_with_tzinfo(self):
+        try:
+            import pytz
+            tz = pytz.timezone('America/Los_Angeles')
+            ts0_pst = tz.localize(ts0)
+            utm = unix_time_millis(ts0_pst)
+            self.assertEqual(utm, ts0_ts_pst)
+        except ImportError:
+            pass

--- a/riak/tests/test_timeseries_pbuf.py
+++ b/riak/tests/test_timeseries_pbuf.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import datetime
+import six
 import unittest
 
 import riak.pb.riak_ts_pb2
@@ -457,5 +458,6 @@ class TimeseriesPbufTests(IntegrationTestBase, unittest.TestCase):
 
         row = ts_obj.rows[0]
         self.assertEqual(len(row), 5)
-        exp = rows[0]
+        exp = [six.b('hash1'), six.b('user2'), now,
+               six.b('frazzle'), 12.3]
         self.assertEqual(row, exp)

--- a/riak/tz.py
+++ b/riak/tz.py
@@ -1,0 +1,17 @@
+from datetime import tzinfo, timedelta
+
+ZERO = timedelta(0)
+
+class UTC(tzinfo):
+    """UTC"""
+
+    def utcoffset(self, dt):
+        return ZERO
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return ZERO
+
+utc = UTC()

--- a/riak/tz.py
+++ b/riak/tz.py
@@ -2,6 +2,7 @@ from datetime import tzinfo, timedelta
 
 ZERO = timedelta(0)
 
+
 class UTC(tzinfo):
     """UTC"""
 

--- a/riak/util.py
+++ b/riak/util.py
@@ -8,10 +8,18 @@ from collections import Mapping
 from six import string_types, PY2
 
 epoch = datetime.datetime.utcfromtimestamp(0)
-
+try:
+    import pytz
+    epoch_tz = pytz.utc.localize(epoch)
+except ImportError:
+    from riak.tz import utc
+    epoch_tz = datetime.datetime.fromtimestamp(0, tz=utc)
 
 def unix_time_millis(dt):
-    td = dt - epoch
+    if dt.tzinfo:
+        td = dt - epoch_tz
+    else:
+        td = dt - epoch
     tdms = ((td.days * 24 * 3600) + td.seconds) * 1000
     ms = td.microseconds // 1000
     return tdms + ms

--- a/riak/util.py
+++ b/riak/util.py
@@ -15,6 +15,7 @@ except ImportError:
     from riak.tz import utc
     epoch_tz = datetime.datetime.fromtimestamp(0, tz=utc)
 
+
 def unix_time_millis(dt):
     if dt.tzinfo:
         td = dt - epoch_tz

--- a/tox.ini
+++ b/tox.ini
@@ -12,5 +12,5 @@ basepython = {env:HOME}/.pyenv/versions/riak-py278/bin/python2.7
 [testenv]
 install_command = pip install --upgrade {packages}
 commands = {envpython} setup.py test
-deps = pip
+deps = pip pytz
 passenv = RUN_* SKIP_* RIAK_*

--- a/tox.ini
+++ b/tox.ini
@@ -12,5 +12,7 @@ basepython = {env:HOME}/.pyenv/versions/riak-py278/bin/python2.7
 [testenv]
 install_command = pip install --upgrade {packages}
 commands = {envpython} setup.py test
-deps = pip pytz
+deps =
+    pip
+    pytz
 passenv = RUN_* SKIP_* RIAK_*


### PR DESCRIPTION
Take datetime objects into account that have tzinfo information. Fixes #483 (CLIENTS-39) (CLIENTS-897)