### PR TITLE
Fix riak_pb to pass bytes to _ParseOptions

### DIFF
--- a/riak/pb/riak_dt_pb2.py
+++ b/riak/pb/riak_dt_pb2.py
@@ -995,5 +995,5 @@ class DtUpdateResp(_message.Message):
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), '\n\027com.basho.riak.protobufB\010RiakDtPB')
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), b'\n\027com.basho.riak.protobufB\010RiakDtPB')
 # @@protoc_insertion_point(module_scope)

--- a/riak/pb/riak_kv_pb2.py
+++ b/riak/pb/riak_kv_pb2.py
@@ -1983,5 +1983,5 @@ class RpbCoverageEntry(_message.Message):
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), '\n\027com.basho.riak.protobufB\010RiakKvPB')
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), b'\n\027com.basho.riak.protobufB\010RiakKvPB')
 # @@protoc_insertion_point(module_scope)

--- a/riak/pb/riak_pb2.py
+++ b/riak/pb/riak_pb2.py
@@ -803,5 +803,5 @@ class RpbAuthReq(_message.Message):
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), '\n\027com.basho.riak.protobufB\006RiakPB')
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), b'\n\027com.basho.riak.protobufB\006RiakPB')
 # @@protoc_insertion_point(module_scope)

--- a/riak/pb/riak_search_pb2.py
+++ b/riak/pb/riak_search_pb2.py
@@ -220,5 +220,5 @@ class RpbSearchQueryResp(_message.Message):
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), '\n\027com.basho.riak.protobufB\014RiakSearchPB')
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), b'\n\027com.basho.riak.protobufB\014RiakSearchPB')
 # @@protoc_insertion_point(module_scope)

--- a/riak/pb/riak_ts_pb2.py
+++ b/riak/pb/riak_ts_pb2.py
@@ -930,5 +930,5 @@ class TsRange(_message.Message):
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), '\n\027com.basho.riak.protobufB\010RiakTsPB')
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), b'\n\027com.basho.riak.protobufB\010RiakTsPB')
 # @@protoc_insertion_point(module_scope)

--- a/riak/pb/riak_yokozuna_pb2.py
+++ b/riak/pb/riak_yokozuna_pb2.py
@@ -382,5 +382,5 @@ class RpbYokozunaSchemaGetResp(_message.Message):
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), '\n\027com.basho.riak.protobufB\016RiakYokozunaPB')
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), b'\n\027com.basho.riak.protobufB\016RiakYokozunaPB')
 # @@protoc_insertion_point(module_scope)


### PR DESCRIPTION
This fixes errors like the following observed with protobuf-3.3.0:
```python
Traceback (most recent call last):
  File "/usr/lib64/python3.4/site-packages/google/protobuf/internal/python_message.py", line 1063, in MergeFromString
    if self._InternalParse(serialized, 0, length) != length:
  File "/usr/lib64/python3.4/site-packages/google/protobuf/internal/python_message.py", line 1085, in InternalParse
    (tag_bytes, new_pos) = local_ReadTag(buffer, pos)
  File "/usr/lib64/python3.4/site-packages/google/protobuf/internal/decoder.py", line 181, in ReadTag
    while six.indexbytes(buffer, pos) & 0x80:
TypeError: unsupported operand type(s) for &: 'str' and 'int'

During handling of the above exception, another exception occurred:

  File "riak-2.7.0/riak/pb/riak_dt_pb2.py", line 984, in <module>
    DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), '\n\027com.basho.riak.protobufB\010RiakDtPB')
  File "/usr/lib64/python3.4/site-packages/google/protobuf/descriptor.py", line 869, in _ParseOptions
    message.ParseFromString(string)
  File "/usr/lib64/python3.4/site-packages/google/protobuf/message.py", line 185, in ParseFromString
    self.MergeFromString(serialized)
  File "/usr/lib64/python3.4/site-packages/google/protobuf/internal/python_message.py", line 1069, in MergeFromString
    raise message_mod.DecodeError('Truncated message.')
google.protobuf.message.DecodeError: Truncated message.
```