### PR TITLE
Do not use deprecated argument `verbose` in namedtuple

### DIFF
--- a/riak/codecs/__init__.py
+++ b/riak/codecs/__init__.py
@@ -21,8 +21,7 @@ from riak.codecs.util import parse_pbuf_msg
 from riak.util import bytes_to_str
 
 Msg = collections.namedtuple('Msg',
-                             ['msg_code', 'data', 'resp_code'],
-                             verbose=False)
+                             ['msg_code', 'data', 'resp_code'])
 
 
 class Codec(object):


### PR DESCRIPTION
Argument `verbose` to nametuple constructor was deprecated in Python 3.3, and was removed in Python 3.7.

This PR fixes the issue with Python 3.7 where trying to `import riak` raises an exception with message `TypeError: namedtuple() got an unexpected keyword argument 'verbose'`.
