### PR TITLE
Reduce test time - test only 2.7, 3.6, and nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ dist: trusty
 language: python
 python:
   - '2.7'
-  - '3.3'
-  - '3.4'
-  - '3.5'
   - '3.6'
   - nightly
 addons:


### PR DESCRIPTION
test only 2.7 (stable), 3.6 (3 series stable) and nightly - the matrix was too big - 3.2, 3.3, 3.4, and 3.5 are the least used.