### PR TITLE
fix for riak 3.0x 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "riak_pb"]
 	path = riak_pb
-	url = git://github.com/basho/riak_pb.git
+	url = https://github.com/basho/riak_pb.git
 [submodule "tools"]
 	path = tools
-	url = git://github.com/basho/riak-client-tools.git
+	url = https://github.com/basho/riak-client-tools.git
 [submodule "docs"]
 	path = docs
 	url = https://github.com/basho/riak-python-client.git

--- a/riak/tests/test_transports_tcp_transport.py
+++ b/riak/tests/test_transports_tcp_transport.py
@@ -1,0 +1,14 @@
+import unittest
+
+from riak.transports.tcp import TcpTransport
+from riak.node import RiakNode
+
+
+class TransportsTCPTransportTests(unittest.TestCase):
+    def test__server_version(self):
+        node = RiakNode()
+        transport = TcpTransport(node=node)
+        transport.get_server_info = lambda: {'server_version': '2.1.2'}
+        self.assertEqual('2.1.2', transport._server_version())
+        transport.get_server_info = lambda: {'server_version': '3.0'}
+        self.assertEqual('3.0', transport._server_version())

--- a/riak/transports/tcp/transport.py
+++ b/riak/transports/tcp/transport.py
@@ -93,16 +93,7 @@ class TcpTransport(Transport, TcpConnection):
     # FeatureDetection API
     def _server_version(self):
         server_info = self.get_server_info()
-        ver = server_info['server_version']
-        (maj, min, patch) = [int(v) for v in ver.split('.')]
-        if maj == 0:
-            import datetime
-            now = datetime.datetime.now()
-            if now.year == 2016:
-                # GH-471 As of 20160509 Riak TS OSS 1.3.0 returns '0.8.0' as
-                # the version string.
-                return '2.1.1'
-        return ver
+        return server_info['server_version']
 
     def ping(self):
         """


### PR DESCRIPTION
in case of riak 3.0x server returns 3.0 as version and 'maj' version
detection logic was crashing.

since this piece of code will be used definitely after 2016, lines which
caused crashed can be safely removed.